### PR TITLE
Update Table_16_Soil_N2O_Emission_Factors_Provider.cs

### DIFF
--- a/H.Core/Providers/Soil/Table_16_Soil_N2O_Emission_Factors_Provider.cs
+++ b/H.Core/Providers/Soil/Table_16_Soil_N2O_Emission_Factors_Provider.cs
@@ -203,7 +203,7 @@ namespace H.Core.Providers.Soil
                     return 0.90;
 
                 case SoilReductionFactors.UreaseInhibitor:
-                    return 0.14;
+                    return 1.14;
 
                 case SoilReductionFactors.NitrificationAndUreaseInhibitor:
                     return 0.94;


### PR DESCRIPTION
urease inhibitors are currently considered to increase N2O by 14%. This was updated recently, but for some reason undone.