### PR TITLE
Table 27 edits

### DIFF
--- a/H.Core/Providers/Animals/Table_27_Enteric_CH4_Swine_Poultry_OtherLivestock_Provider.cs
+++ b/H.Core/Providers/Animals/Table_27_Enteric_CH4_Swine_Poultry_OtherLivestock_Provider.cs
@@ -8,7 +8,6 @@ namespace H.Core.Providers.Animals
 {
     /// <summary>
     /// Table 27. Enteric CH4 emission rates for swine, poultry and other livestock groups
-    /// <para>Source: IPCC (2019), Table 10.10.</para>
     /// </summary>
     public class Table_27_Enteric_CH4_Swine_Poultry_OtherLivestock_Provider 
     {
@@ -28,12 +27,31 @@ namespace H.Core.Providers.Animals
         public double GetAnnualEntericMethaneEmissionRate(AnimalType animalType)
         {
             
-            if (animalType.IsSwineType()) // Footnote 1
+            if (animalType == AnimalType.SwineSows || animalType == AnimalType.SwineLactatingSow || animalType == AnimalType.SwineDrySow) // Footnote 1
+            {
+                return 2.42;
+            }
+            
+            if (animalType == AnimalType.SwineBoar) // Footnote 1
+            {
+                return 2.64;
+            }
+               
+            if (animalType == AnimalType.SwineGilts) // Footnote 1
             {
                 return 1.5;
             }
-
+                
+            if (animalType == AnimalType.SwineGrower || animalType == AnimalType.SwineFinisher) // Footnote 1
+            {
+                return 1.5;
+            }
             
+            if (animalType == AnimalType.Starter) // Footnote 1
+            {
+                return 0.23;
+            }
+                           
             if (animalType.IsPoultryType()) // Footnote 2
             {
                 return 0;
@@ -43,14 +61,12 @@ namespace H.Core.Providers.Animals
             {
                 return 8;
             }
-
             
             if (animalType == AnimalType.Goats) // Footnote 3
             {
                 return 5;
             }
 
-            
             if (animalType == AnimalType.Deer || animalType == AnimalType.Elk) // Footnote 4
             {
                 return 20;
@@ -66,7 +82,6 @@ namespace H.Core.Providers.Animals
                 return 10;
             }
 
-            
             if (animalType == AnimalType.Bison) // Footnote 5
             {
                 return 64;
@@ -81,9 +96,9 @@ namespace H.Core.Providers.Animals
 
         #region Footnotes
 
-        // Footnote 1: High productivity systems
+ 	    // Footnote 1: Source: Verge et al. (2009)
         // Footnote 2: Due to insufficient data, no default enteric CH4 emission factors are available for poultry (IPCC, 2019)
-        // Footnote 3: Low productivity systems
+        // Footnote 3: Low productivity systems. Source: IPCC (2019), Table 10.10
         // Footnote 4: Elk were added to this category
         // Footnote 5: Value for “other (non-dairy) cattle” in North America (from IPCC (2019), Table 10.11) was used
 

--- a/H.Core/Providers/Animals/Table_27_Enteric_CH4_Swine_Poultry_OtherLivestock_Provider.cs
+++ b/H.Core/Providers/Animals/Table_27_Enteric_CH4_Swine_Poultry_OtherLivestock_Provider.cs
@@ -39,10 +39,15 @@ namespace H.Core.Providers.Animals
                
             if (animalType == AnimalType.SwineGilts) // Footnote 1
             {
-                return 1.5;
+                return 2.42;
             }
                 
-            if (animalType == AnimalType.SwineGrower || animalType == AnimalType.SwineFinisher) // Footnote 1
+            if (animalType == AnimalType.SwineGrower) // Footnote 1
+            {
+                return 0.7;
+            }
+            
+            if (animalType == AnimalType.SwineFinisher) // Footnote 1
             {
                 return 1.5;
             }

--- a/H.Core/Providers/Animals/Table_32_Swine_VS_Nitrogen_Excretion_Factors_Provider.cs
+++ b/H.Core/Providers/Animals/Table_32_Swine_VS_Nitrogen_Excretion_Factors_Provider.cs
@@ -10,7 +10,7 @@ namespace H.Core.Providers.Animals
 {
     /// <summary>
     /// Table 32. Volatile solid and nitrogen excretion adjustment factors for swine, by diet.
-    /// <para>Greenhouse Gas System Pork Protocol 2006</para>
+    /// <para>Greenhouse Gas System Pork Protocol 2006. Note: the VS and N adjustment factors used in Holos for all diets are currently set to 1, as we work to update the linkages between these factors and the Holos default swine diets</para>
     /// </summary>
     public class Table_32_Swine_VS_Nitrogen_Excretion_Factors_Provider
     {


### PR DESCRIPTION
Changes made to default CH4 emission rates for swine (and relevant footnotes). For growers/finishers, the CH4 rates need to relate to the weight categories defined in Verge et al. for these animals, i.e., 0.7 kg CH4 per head per year for animals 20-60 kg and 1.5 kg CH4 per head per year for animals 60-130 kg. 