### PR TITLE
Update Table_6_Manure_Types_And_Default_Composition.csv

### DIFF
--- a/H.Content/Resources/Table_6_Manure_Types_And_Default_Composition.csv
+++ b/H.Content/Resources/Table_6_Manure_Types_And_Default_Composition.csv
@@ -9,6 +9,7 @@ Dairy cattle,Deep bedding (2),60.08,0.715,12.63,0.223,17.66
 Dairy cattle,Solid storage (7),77.3,0.392,2.99,0.118,7.63
 Dairy cattle,Compost - passive windrow (8),78.11,0.265,4.72,-9,17.81
 Dairy cattle,Compost - intensive windrow (8),78.11,0.265,4.72,-9,17.81
+Swine,Composted in-vessel (9),79.23,0.279,9.13,-9,32.72
 Sheep,Pasture/range/paddock ,75.0 (10),0.765 (10),6.182 (1),0.211 (10),8.08
 Sheep,Solid storage,67.8 (11),0.870 (11),8.58 (3),0.340 (11),9.86
 Poultry,Solid storage - with or without litter (12),44.83,2.427,10.12,1.06,4.17
@@ -28,18 +29,17 @@ Goats,Solid Storage,53.58 (20),0.729 (20),8.58 (3),0.280 (20),11.77
 Horses,Solid Storage,56.65 (21),0.864 (21),8.58 (3),0.155 (21),9.93
 Mules,Solid Storage,56.65 (22),0.864 (22),8.58 (3),0.155 (22),9.93
 Bison,Solid Storage,35 (23),0.638 (23),8.58 (3),0.214 (23),13.45
-Dairy cattle,Daily spread,94.41,0.209,2.19,0.06,10.48
+Dairy cattle,Daily spread (24),94.41,0.209,2.19,0.06,10.48
 Dairy cattle,Liquid/slurry with natural crust (24),94.41,0.209,2.19,0.06,10.48
 Dairy cattle,Liquid/slurry with no natural crust (24),94.41,0.209,2.19,0.06,10.48
 Dairy cattle,Liquid/slurry with solid cover (24),94.41,0.209,2.19,0.06,10.48
 Dairy cattle,Deep pit under barn,94.41,0.209,2.19,0.06,10.48
-Dairy cattle,Anaerobic digestor (26),95,0.106,2.39,-9,22.55
-Swine,Liquid/slurry with natural crust (27),95.16,0.325,1.29,0.118,3.97
-Swine,Liquid/slurry with no natural crust (27),95.16,0.325,1.29,0.118,3.97
-Swine,Liquid/slurry with solid cover (27),95.16,0.325,1.29,0.118,3.97
-Swine,Deep pit under barn (27),95.16,0.325,1.29,0.118,3.97
+Dairy cattle,Anaerobic digestor (25),95,0.106,2.39,-9,22.55
+Swine,Liquid/slurry with natural crust (26),95.16,0.325,1.29,0.118,3.97
+Swine,Liquid/slurry with no natural crust (26),95.16,0.325,1.29,0.118,3.97
+Swine,Liquid/slurry with solid cover (26),95.16,0.325,1.29,0.118,3.97
+Swine,Deep pit under barn (26),95.16,0.325,1.29,0.118,3.97
 Swine,Anaerobic digestion ,0,0,0,0,0
-Swine,Composted in-vessel (9),79.23,0.279,9.13,-9,32.72
 ,,,,,,
 ,,,,,,
 "Data on manure composition were organized from multiple publications based on Canadian studies (extension documents, reports, journal publications). Where data from Canada were not available, data were sourced from outside Canada – any non-Canadian data used is indicated in the relevant notes below.",,,,,,
@@ -59,7 +59,7 @@ Swine,Composted in-vessel (9),79.23,0.279,9.13,-9,32.72
 "14 The Ncontent of goat manure deposited on pasture was calculated using data from ECCC (2021) and Hofmann and Beaulieu (2006); Pcontent was calculated from Hofmann and Beaulieu (2006).",,,,,,
 "15 Default values for moisture content for horse manure deposited on pasture were derived from Bell (1983), for Ncontent from Hofmann and Beaulieu (2006) and ECCC (2021), and for Pcontent from Hofmann and Beaulieu (2006).",,,,,,
 "16 Moisture content, Ncontent and Pcontent values for horses on pasture used for mules on pasture.",,,,,,
-"17 Moisture content, Ncontent and Pcontent values for beef cattle on pasture used for bison on pasture.",,,,,,
+"17 Moisture content, Ncontent, Ccontent and Pcontent values for beef cattle on pasture used for bison on pasture.",,,,,,
 "18 Moisture content, Ncontent and Pcontent values for sheep manure in solid storage are used for llama and alpaca manure in solid storage (drylot).",,,,,,
 "19 Default values for moisture content, Ncontent and Pcontent values for deer/elk manure in solid storage (drylot) were derived from Government of Alberta (2013,2021).",,,,,,
 "20 Moisture content, Ncontent and Pcontent values for manure in solid storage (drylot) for goats derived from Brown (2013); Government of Alberta (2013).",,,,,,
@@ -67,6 +67,5 @@ Swine,Composted in-vessel (9),79.23,0.279,9.13,-9,32.72
 "22 Moisture content, Ncotent and Pcontent values for horse manure in solid storage are used for mule manure in solid storage (drylot).",,,,,,
 "23 Default values for moisture content, Ncontent and Pcontent for bison manure in solid storage (drylot) were derived from: Government of Alberta (2013,2021).",,,,,,
 "24 Default values for moisture content and C, N and P content for liquid/slurry manure for dairy cattle were averages calculated from data derived from the following sources: Paul and Beauchamp (1989,1993); Pattey et al. (2005); The Prairie Provinces’ Committee on Livestock Development and Manure Management (2006a); Government of Manitoba (2009); VanderZaag et al. (2009,2010a,b); Brown (2013); Manitoba Agriculture, Food and Rural Development (2015); LeRiche et al. (2016); Ngwabie et al. (2016); Fillingham et al. (2017); Ackerman et al. (2018); Balde et al. (2018); Johannesson et al. (2018); Kariyapperuma et al. (2018a,b); Maldaner et al. (2018). These default values are used for all dairy liquid/slurry manure types: ""Daily spread"", ""Liquid with natural crust"", ""Liquid with no natural crust"", ""Liquid with solid cover"" and ""Deep pit under barn"" (pit storage below animal confinement).",,,,,,
-"25 Default values for moisture content and C, N and P content for separated liquid manure for dairy cattle were averages calculated from data derived from the following sources: Cambareri et al. (2017); Fillingham et al. (2017); Ackerman et al. (2018); Balde et al. (2018); Evans et al. (2018); VanderZaag et al. (2019).",,,,,,
-"26 Default values for moisture content and C, N and P fractions for anaerobic digestate for dairy cattle were averages calculated from data derived from the following sources: Balde et al. (2018); Evans et al. (2018); Maldaner et al (2018).",,,,,,
-"27 Default values for moisture content and C, N and P content for liquid/slurry for swine were averages calculated from data derived from the following sources: Paul and Beauchamp (1989); Fitzgerald and Racz (2001); Olson and Papworth (2002); Dick (2003); Thompson et al. (2004); The Prairie Provinces’ Committee on Livestock Development and Manure Management (2006a,b); Government of Manitoba (2009); Coppi (2012); Brown (2013); Tenuta et al. (2013); Park et al. (2014); Manitoba Agriculture, Food and Rural Development (2015). These default values are used for all swine liquid/slurry manure types: ""Liquid with natural crust"", ""Liquid with no natural crust"", ""Liquid with solid cover"" And ""Deep pit under barn"" (pit storage below animal confinement).",,,,,,
+"25 Default values for moisture content and C, N and P fractions for anaerobic digestate for dairy cattle were averages calculated from data derived from the following sources: Balde et al. (2018); Evans et al. (2018); Maldaner et al (2018).",,,,,,
+"26 Default values for moisture content and C, N and P content for liquid/slurry for swine were averages calculated from data derived from the following sources: Paul and Beauchamp (1989); Fitzgerald and Racz (2001); Olson and Papworth (2002); Dick (2003); Thompson et al. (2004); The Prairie Provinces’ Committee on Livestock Development and Manure Management (2006a,b); Government of Manitoba (2009); Coppi (2012); Brown (2013); Tenuta et al. (2013); Park et al. (2014); Manitoba Agriculture, Food and Rural Development (2015). These default values are used for all swine liquid/slurry manure types: ""Liquid with natural crust"", ""Liquid with no natural crust"", ""Liquid with solid cover"" And ""Deep pit under barn"" (pit storage below animal confinement).",,,,,,


### PR DESCRIPTION
I have made just minor changes to the table as follows: moved row for "Swine,Composted in-vessel" to between "Dairy cattle,Compost - intensive windrow" and "Sheep,Pasture/range/paddock", as composted swine manure is a solid manure type; added text to note #17; deleted note #25 (relating to separated liquid dairy manure - no longer included in the model) and renumbered subsequent notes accordingly.