### PR TITLE
Update Table_39_Crude_Protein_Content_Swine_Feed_Provider.cs

### DIFF
--- a/H.Core/Providers/Animals/Table_39_Crude_Protein_Content_Swine_Feed_Provider.cs
+++ b/H.Core/Providers/Animals/Table_39_Crude_Protein_Content_Swine_Feed_Provider.cs
@@ -9,8 +9,8 @@ using H.Infrastructure;
 namespace H.Core.Providers.Animals
 {
     /// <summary>
-    /// Table 39. Crude protein content in feed, as fed, for each pig group, by province.
-    /// <para>Source: Greenhouse Gas System Pork Protocol (2006)</para>
+    /// Table 39. Crude protein content in feed, as fed (% of feed intake), by swine group.
+    /// <para>Source: D. Beaulieu, U. of Saskatchewan, (pers. comm.)</para>
     /// </summary>
     public class Table_39_Crude_Protein_Content_Swine_Feed_Provider
     {
@@ -33,50 +33,49 @@ namespace H.Core.Providers.Animals
 
         #region Public Methods
 
-        public Dictionary<AnimalType, double> GetByProvince(Province province)
+        public Dictionary<DietType, double> GetByProvince(Province province)
         {
             switch (province)
             {
+                
+                case Province.BritishColumbia:
+                case Province.Alberta:
+                case Province.Saskatchewan:
+                case Province.Manitoba:
                 case Province.Ontario:
                 case Province.Quebec:
-                    return new Dictionary<AnimalType, double>
+                case Province.NewBrunswick:
+                case Province.NovaScotia:
+                case Province.PrinceEdwardIsland:
+                case Province.Newfoundland:
+                    return new Dictionary<DietType, double>
                     {
-                        {AnimalType.SwineStarter, 0.210},
-                        {AnimalType.SwineGrower, 0.175},
-                        {AnimalType.SwineFinisher, 0.135},
-                        {AnimalType.SwineDrySow, 0.135},
-                        {AnimalType.SwineGilts, 0.145},
-                        {AnimalType.SwineBoar, 0.135},
-                        {AnimalType.SwineLactatingSow, 0.185}
+                        {DietType.Gestation, 14.28},
+                        {DietType.Lactation, 19.07},
+                        {DietType.NurseryWeanersStarter1, 23.88},
+                        {DietType.NurseryWeanersStarter2, 21.45},
+                        {DietType.GrowerFinisherDiet1, 20.27},
+                        {DietType.GrowerFinisherDiet2, 19.89},
+                        {DietType.GrowerFinisherDiet3, 19.92},
+                        {DietType.GrowerFinisherDiet4, 19.66},
+                        {DietType.Boar, 20.1}
                     };
 
-                default:
-                    var defaultValue = new Dictionary<AnimalType, double>
-                    {
-                        {AnimalType.SwineStarter, 0.220},
-                        {AnimalType.SwineGrower, 0.180},
-                        {AnimalType.SwineFinisher, 0.155},
-                        {AnimalType.SwineDrySow, 0.145},
-                        {AnimalType.SwineGilts, 0.145},
-                        {AnimalType.SwineBoar, 0.135},
-                        {AnimalType.SwineLactatingSow, 0.200}
-                    };
-
-                    return defaultValue;
-            }
+               
+                    }
         }
 
-        public double GetCrudeProteinInFeedForSwineGroupByProvince(Province province, AnimalType animalType)
+        public double GetCrudeProteinInFeedForSwineGroupByProvince(Province province, DietType dietType)
         {
             var byProvince = this.GetByProvince(province);
-            if (byProvince.ContainsKey(animalType))
+            if (byProvince.ContainsKey(dietType))
             {
-                return byProvince[animalType];
+                return byProvince[dietType];
             }
             else
             {
                 System.Diagnostics.Trace.TraceError($"{nameof(Table_39_Crude_Protein_Content_Swine_Feed_Provider)}.{nameof(GetCrudeProteinInFeedForSwineGroupByProvince)}" +
-                                                    $" unable to get data for province: {province} and animal type: {animalType.GetDescription()}" +
+                                                    $" unable to get data for province: {province} and diet type: {dietType.GetDescription()}" +
                                                     $" Returning default value of 0.");
 
                 return 0;


### PR DESCRIPTION
Changed CP values to align with Denise's swine diet data. Please check that I didn't mess up the code. Note: I have included the CP for the boar diet, but I am not sure if this has yet been added as a default diet in Holos. Note: In the alg doc (Eq. 4.2.1-19), the CP is assumed to be a fraction (kg CP per kf feed), as the original data (from the Pork Protocol) were fractions; if the CP is currently reported as a percentage in the Holos code, let me know and I will add a divisor of 100 to this equation.