### PR TITLE
Update Table_36_Livestock_Emission_Conversion_Factors_Provider.cs

### DIFF
--- a/H.Core/Providers/Animals/Table_36_Livestock_Emission_Conversion_Factors_Provider.cs
+++ b/H.Core/Providers/Animals/Table_36_Livestock_Emission_Conversion_Factors_Provider.cs
@@ -64,7 +64,7 @@ namespace H.Core.Providers.Animals
 
             if (region == Region.WesternCanada)
             {
-                factors.N20DirectEmissionFactor = 0.0006;
+                factors.N20DirectEmissionFactor = 0.00043;
             }
             else
             {


### PR DESCRIPTION
Changed direct N2O EF for pasture for Western Canada from 0.0006 to 0.00043