### PR TITLE
Update Table_47_Solid_Liquid_Separation_Coefficients_Provider.cs

### DIFF
--- a/H.Core/Providers/AnaerobicDigestion/Table_47_Solid_Liquid_Separation_Coefficients_Provider.cs
+++ b/H.Core/Providers/AnaerobicDigestion/Table_47_Solid_Liquid_Separation_Coefficients_Provider.cs
@@ -85,8 +85,8 @@ namespace H.Core.Providers.AnaerobicDigestion
                     return new SolidLiquidSeparationCoefficientsData
                     {
                         SeparationCoefficient = SeparationCoefficients.FractionCarbon,
-                        Centrifuge = 0.0,
-                        BeltPress = 0.0,
+                        Centrifuge = 0.81,
+                        BeltPress = 0.32,
                     };
 
                 default:


### PR DESCRIPTION
Added values for separation coefficient for carbon - these values are the same as those for total solids (TS) as we currently have no better values.