### PR TITLE
Force latitude and longitude to always use english formatting

### DIFF
--- a/H.Core/Providers/Climate/NasaClimateProvider.cs
+++ b/H.Core/Providers/Climate/NasaClimateProvider.cs
@@ -1,15 +1,13 @@
-﻿using H.Core.Tools;
+﻿using H.Core.Calculators.Climate;
+using H.Core.Tools;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using H.Core.Calculators.Climate;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace H.Core.Providers.Climate
 {
@@ -39,7 +37,7 @@ namespace H.Core.Providers.Climate
         #endregion
 
         #region Constructors
-        
+
         public NasaClimateProvider()
         {
             HTraceListener.AddTraceListener();
@@ -213,13 +211,8 @@ namespace H.Core.Providers.Climate
             // ALLSKY_SFC_SW_DWN: All Sky Insolation Incident on a Horizontal Surface (AKA solar radiation) (MJ/m^2/day *when AG community type is specified)
             var parameters = "T2M,PRECTOTCORR,RH2M,ALLSKY_SFC_SW_DWN";
 
-            var latitudeString = latitude.ToString();
-            var longitudeString = longitude.ToString();
-            if (currentCulture == Infrastructure.InfrastructureConstants.FrenchCultureInfo)
-            {
-                latitudeString = latitude.ToString(Infrastructure.InfrastructureConstants.EnglishCultureInfo.NumberFormat);
-                longitudeString = longitude.ToString(Infrastructure.InfrastructureConstants.EnglishCultureInfo.NumberFormat);
-            }
+            var latitudeString = latitude.ToString(Infrastructure.InfrastructureConstants.EnglishCultureInfo.NumberFormat);
+            var longitudeString = longitude.ToString(Infrastructure.InfrastructureConstants.EnglishCultureInfo.NumberFormat);
 
             var parameterPath = $"parameters={parameters}&community={userCommunity}&longitude={longitudeString}&latitude={latitudeString}&start={startDate}&end={endDate}&format={format}";
 


### PR DESCRIPTION
Existing code checks if current culture is set to `fr-CA`, and if it is, forces the latitude and longitude to be formatted using english culture information instead. This causes an issue for us downstream as we're only using `fr` to denote language and omit the locale.

This change removes the check and always forces latitude and longitude to use `en-CA` as the culture info regardless of whether the language is English or French. Should have no effect as non-French users are presumably already using English.