### PR TITLE
Automatically publish releases based on completed PRs

### DIFF
--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -38,7 +38,7 @@ jobs:
         Configuration: ${{ inputs.configuration }}
 
     - name: Run Tests
-      run: vstest.console.exe ./**/H.Core.Test/bin/${{ inputs.configuration }}/H.Core.Test.dll ./**/H.Infrastructure.Test/bin/${{ inputs.configuration }}/H.Infrastructure.Test.dll ./**/H.CLI.Test/bin/${{ inputs.configuration }}/H.CLI.Test.dll ./**/H.Integration/bin/${{ inputs.configuration }}/H.Integration.dll /Parallel
+      run: vstest.console.exe ./**/H.Core.Test/bin/${{ inputs.configuration }}/H.Core.Test.dll ./**/H.Infrastructure.Test/bin/${{ inputs.configuration }}/H.Infrastructure.Test.dll ./**/H.CLI.Test/bin/${{ inputs.configuration }}/H.CLI.Test.dll /Parallel
 
     - name: Upload build artifacts
       if: ${{ inputs.configuration == 'Release' }}

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_call:
+    inputs:
+      configuration:
+        type: string
+
+jobs:
+  reusable_workflow_job:
+    runs-on:  windows-2019
+    env:
+      Solution_Name: Holos.sln
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0        
+
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup VSTest
+      uses: darenm/Setup-VSTest@v1
+
+    - name: Restore nuget packages
+      run: msbuild $env:Solution_Name /t:Restore /m
+      env:
+        Configuration: ${{ inputs.configuration }}
+
+    - name: Build solution
+      run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
+      env:
+        Configuration: ${{ inputs.configuration }}
+
+    - name: Run Tests
+      run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
+
+    # - name: Upload build artifacts
+    #   if: ${{ inputs.configuration == 'Release' }}
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: Holos4-lib
+    #     path: '**/H.Core/bin/*'

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -37,8 +37,8 @@ jobs:
       env:
         Configuration: ${{ inputs.configuration }}
 
-    # - name: Run Tests
-    #   run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
+    - name: Run Tests
+      run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
 
     - name: Upload build artifacts
       if: ${{ inputs.configuration == 'Release' }}

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   reusable_workflow_job:
-    runs-on:  windows-2019
+    runs-on:  windows-latest
     env:
       Solution_Name: Holos.sln
     steps:

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -1,3 +1,5 @@
+name: '[Reusable] Build'
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -3,6 +3,8 @@ on:
     inputs:
       configuration:
         type: string
+      solution:
+        type: string
 
 jobs:
   reusable_workflow_job:
@@ -22,12 +24,12 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Restore nuget packages
-      run: msbuild $env:Solution_Name /t:Restore /m
+      run: msbuild ${{ inputs.solution }} /t:Restore /m
       env:
         Configuration: ${{ inputs.configuration }}
 
     - name: Build solution
-      run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
+      run: msbuild ${{ inputs.solution }} /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
       env:
         Configuration: ${{ inputs.configuration }}
 

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -5,6 +5,8 @@ on:
         type: string
       solution:
         type: string
+      filename:
+        type: string
 
 jobs:
   reusable_workflow_job:
@@ -33,12 +35,12 @@ jobs:
       env:
         Configuration: ${{ inputs.configuration }}
 
-    - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
+    # - name: Run Tests
+    #   run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
 
-    # - name: Upload build artifacts
-    #   if: ${{ inputs.configuration == 'Release' }}
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: Holos4-lib
-    #     path: '**/H.Core/bin/*'
+    - name: Upload build artifacts
+      if: ${{ inputs.configuration == 'Release' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: Holos4-lib
+        path: '**/H.Core/bin/*'

--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -38,7 +38,7 @@ jobs:
         Configuration: ${{ inputs.configuration }}
 
     - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ inputs.configuration }}/H.*.Test.dll /Parallel
+      run: vstest.console.exe ./**/H.Core.Test/bin/${{ inputs.configuration }}/H.Core.Test.dll ./**/H.Infrastructure.Test/bin/${{ inputs.configuration }}/H.Infrastructure.Test.dll ./**/H.CLI.Test/bin/${{ inputs.configuration }}/H.CLI.Test.dll ./**/H.Integration/bin/${{ inputs.configuration }}/H.Integration.dll /Parallel
 
     - name: Upload build artifacts
       if: ${{ inputs.configuration == 'Release' }}

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: holos4
-        release_name: Holos 4 - ${{ github.event.repository.updated_at }}
+        release_name: Holos 4 - ${{ github.event.pull_request.created_at }}
         draft: true
         prerelease: false
 

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
+        tag_name: holos4
         release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -20,13 +20,16 @@ jobs:
         files: H.Core/
         dest: ${{ inputs.filename }}.zip
 
+    - name: Add SHORT_SHA env property with commit short sha
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
     - name: Create Draft Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: holos4
+        tag_name: ${SHORT_SHA}
         release_name: Holos 4 - ${{ github.event.pull_request.created_at }}
         draft: true
         prerelease: false

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -1,3 +1,5 @@
+name: '[Reusable] Publish new release'
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -1,0 +1,45 @@
+on:
+  workflow_call:
+    inputs:
+      filename:
+        type: string
+
+jobs:
+  reusable_workflow_job:
+    runs-on:  ubuntu-latest
+    steps:
+    - name: "Download build"
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.filename }}
+
+    - uses: vimtor/action-zip@v1.2
+      with:
+        files: H.Core/
+        dest: ${{ inputs.filename }}.zip
+
+    - name: Create Draft Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Holos 4 - ${{ github.event.repository.updated_at }}
+        draft: true
+        prerelease: false
+
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ inputs.filename }}.zip
+        asset_name: ${{ inputs.filename }}.zip
+        asset_content_type: application/zip
+
+    - uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -20,8 +20,9 @@ jobs:
         files: H.Core/
         dest: ${{ inputs.filename }}.zip
 
-    - name: Add SHORT_SHA env property with commit short sha
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+    - name: Set short SHA
+      id: vars
+      run: echo "sha_short=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_OUTPUT
 
     - name: Create Draft Release
       id: create_release
@@ -29,8 +30,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${SHORT_SHA}
-        release_name: Holos 4 - ${{ github.event.pull_request.created_at }}
+        tag_name: ${{ steps.vars.outputs.sha_short }}
+        release_name: Holos 4 - ${{ steps.vars.outputs.sha_short }}
         draft: true
         prerelease: false
 

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "pr-test" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -6,85 +6,14 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        # Only do release build. Doing both Debug and Release causes file access error as both will attempt to write to climate data file at the same time
-        configuration: [Release]
-    runs-on:  windows-2019
-    env:
-      Solution_Name: Holos.sln
+    uses: ./.github/workflows/_dotnet-build-template.yml
+    with:
+      configuration: Release
+      solution: Holos.sln
+      filename: Holos4-lib
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0        
-
-  #   - name: Setup MSBuild.exe
-  #     uses: microsoft/setup-msbuild@v2
-
-  #   - name: Setup VSTest
-  #     uses: darenm/Setup-VSTest@v1
-
-  #   - name: Restore nuget packages
-  #     run: msbuild $env:Solution_Name /t:Restore /m
-  #     env:
-  #       Configuration: ${{ matrix.configuration }}
-
-  #   - name: Build solution
-  #     run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
-  #     env:
-  #       Configuration: ${{ matrix.configuration }}
-
-  #   - name: Run Tests
-  #     run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel
-
-  #   - name: Upload build artifacts
-  #     if: ${{ matrix.configuration == 'Release' }}
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Holos4-lib
-  #       path: '**/H.Core/bin/*'
-
-  # release:
-  #   needs: build
-  #   runs-on:  windows-2019 # TODO: might be able to use ubuntu here
-  #   steps:
-  #   - name: "Download build"
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Holos4-lib
-
-  #   - name: list directory (DEBUGGING)
-  #     run: ls
-
-  #   - uses: vimtor/action-zip@v1.2
-  #     with:
-  #       files: H.Core/
-  #       dest: Holos4-lib.zip
-
-  #   - name: Create Draft Release
-  #     id: create_release
-  #     uses: actions/create-release@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       tag_name: ${{ github.ref }}
-  #       release_name: Holos 4 - ${{ github.event.repository.updated_at }}
-  #       draft: true
-  #       prerelease: false
-
-  #   - uses: actions/upload-release-asset@v1.0.1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ steps.create_release.outputs.upload_url }}
-  #       asset_path: Holos4-lib.zip
-  #       asset_name: Holos4-lib.zip
-  #       asset_content_type: application/zip
-
-  #   - uses: eregon/publish-release@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       release_id: ${{ steps.create_release.outputs.id }}
+  publish:
+    needs: build
+    uses: ./.github/workflows/_dotnet-publish-template.yml
+    with:
+      filename: Holos4-lib

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -2,9 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "testing" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: [ "pr-test" ]
 
 jobs:
   build:
@@ -22,71 +20,71 @@ jobs:
       with:
         fetch-depth: 0        
 
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
+  #   - name: Setup MSBuild.exe
+  #     uses: microsoft/setup-msbuild@v2
 
-    - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1
+  #   - name: Setup VSTest
+  #     uses: darenm/Setup-VSTest@v1
 
-    - name: Restore nuget packages
-      run: msbuild $env:Solution_Name /t:Restore /m
-      env:
-        Configuration: ${{ matrix.configuration }}
+  #   - name: Restore nuget packages
+  #     run: msbuild $env:Solution_Name /t:Restore /m
+  #     env:
+  #       Configuration: ${{ matrix.configuration }}
 
-    - name: Build solution
-      run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
-      env:
-        Configuration: ${{ matrix.configuration }}
+  #   - name: Build solution
+  #     run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
+  #     env:
+  #       Configuration: ${{ matrix.configuration }}
 
-    - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel
+  #   - name: Run Tests
+  #     run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel
 
-    - name: Upload build artifacts
-      if: ${{ matrix.configuration == 'Release' }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Holos4-lib
-        path: '**/H.Core/bin/*'
+  #   - name: Upload build artifacts
+  #     if: ${{ matrix.configuration == 'Release' }}
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: Holos4-lib
+  #       path: '**/H.Core/bin/*'
 
-  release:
-    needs: build
-    runs-on:  windows-2019 # TODO: might be able to use ubuntu here
-    steps:
-    - name: "Download build"
-      uses: actions/download-artifact@v4
-      with:
-        name: Holos4-lib
+  # release:
+  #   needs: build
+  #   runs-on:  windows-2019 # TODO: might be able to use ubuntu here
+  #   steps:
+  #   - name: "Download build"
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Holos4-lib
 
-    - name: list directory (DEBUGGING)
-      run: ls
+  #   - name: list directory (DEBUGGING)
+  #     run: ls
 
-    - uses: vimtor/action-zip@v1.2
-      with:
-        files: H.Core/
-        dest: Holos4-lib.zip
+  #   - uses: vimtor/action-zip@v1.2
+  #     with:
+  #       files: H.Core/
+  #       dest: Holos4-lib.zip
 
-    - name: Create Draft Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Holos 4 - ${{ github.event.repository.updated_at }}
-        draft: true
-        prerelease: false
+  #   - name: Create Draft Release
+  #     id: create_release
+  #     uses: actions/create-release@v1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       tag_name: ${{ github.ref }}
+  #       release_name: Holos 4 - ${{ github.event.repository.updated_at }}
+  #       draft: true
+  #       prerelease: false
 
-    - uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Holos4-lib.zip
-        asset_name: Holos4-lib.zip
-        asset_content_type: application/zip
+  #   - uses: actions/upload-release-asset@v1.0.1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #       asset_path: Holos4-lib.zip
+  #       asset_name: Holos4-lib.zip
+  #       asset_content_type: application/zip
 
-    - uses: eregon/publish-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        release_id: ${{ steps.create_release.outputs.id }}
+  #   - uses: eregon/publish-release@v1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build and publish new release
 
 on:
   push:

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -10,7 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        # Only do release build. Doing both Debug and Release causes file access error as both will attempt to write to climate data file at the same time
+        configuration: [Release]
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln
@@ -38,7 +39,7 @@ jobs:
         Configuration: ${{ matrix.configuration }}
 
     - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
+      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel
 
     - name: Upload build artifacts
       if: ${{ matrix.configuration == 'Release' }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -37,15 +37,15 @@ jobs:
       env:
         Configuration: ${{ matrix.configuration }}
 
-    - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
+    # - name: Run Tests
+    #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
-    # - name: Upload build artifacts
-    #   if: ${{ matrix.configuration == 'Release' }}
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: Files-${{ matrix.configuration }}
-    #     path: '**/*/bin/*'
+    - name: Upload build artifacts
+      if: ${{ matrix.configuration == 'Release' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: Files-${{ matrix.configuration }}
+        path: '**/*/bin/*'
 
     - name: Set current date as env variable
       run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
@@ -57,7 +57,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.sha }}
-        release_name: Holos 4 - $NOW
+        release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false
 
@@ -66,8 +66,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./Files-Release.zip
-        asset_name: Files-Release.zip
+        asset_path: ./Files-${{ matrix.configuration }}.zip
+        asset_name: Files-${{ matrix.configuration }}.zip
         asset_content_type: application/zip
 
     - uses: eregon/publish-release@v1

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -28,12 +28,12 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Restore nuget packages
-      run: msbuild $env:Solution_Name /t:Restore
+      run: msbuild $env:Solution_Name /t:Restore /m
       env:
         Configuration: ${{ matrix.configuration }}
 
     - name: Build solution
-      run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration
+      run: msbuild $env:Solution_Name /p:platform="Any CPU" /p:Configuration=$env:Configuration /m
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -70,7 +70,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.event.repository.updated_at }}
         release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,36 +40,42 @@ jobs:
     # - name: Run Tests
     #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
-    # - name: Upload build artifacts
-    #   if: ${{ matrix.configuration == 'Release' }}
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: Holos4-lib
-    #     path: '**/H.Core/bin/*'
-
-    - uses: vimtor/action-zip@v1.2
+    - name: Upload build artifacts
       if: ${{ matrix.configuration == 'Release' }}
+      uses: actions/upload-artifact@v4
       with:
-        files: H.Core/bin/
-        dest: Holos4-lib.zip
+        name: Holos4-lib
+        path: '**/H.Core/bin/*'
+
+  release:
+    needs: build
+    runs-on:  windows-2019 # TODO: might be able to use ubuntu here
+    steps:
+    - name: "Download build"
+      uses: actions/download-artifact@v4
+      with:
+        name: Holos4-lib
 
     - name: list directory (DEBUGGING)
       run: ls
 
+    - uses: vimtor/action-zip@v1.2
+      with:
+        files: H.Core/
+        dest: Holos4-lib.zip
+
     - name: Create Draft Release
-      if: ${{ matrix.configuration == 'Release' }}
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.sha }}
+        tag_name: holos4 # ${{ github.sha }}
         release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false
 
     - uses: actions/upload-release-asset@v1.0.1
-      if: ${{ matrix.configuration == 'Release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -79,7 +85,6 @@ jobs:
         asset_content_type: application/zip
 
     - uses: eregon/publish-release@v1
-      if: ${{ matrix.configuration == 'Release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,15 +40,25 @@ jobs:
     # - name: Run Tests
     #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
+    - name: list directory (DEBUGGING)
+      run: ls
+
     - name: Upload build artifacts
       if: ${{ matrix.configuration == 'Release' }}
       uses: actions/upload-artifact@v4
       with:
         name: Files-${{ matrix.configuration }}
         path: '**/*/bin/*'
+        
+    - name: list directory (DEBUGGING)
+      run: ls
 
-    - name: Set current date as env variable
-      run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
+  release:
+    needs: build
+    runs-on:  windows-2019 # TODO: might be able to use ubuntu here
+    steps:
+    - name: list directory (DEBUGGING)
+      run: ls
 
     - name: Create Draft Release
       if: ${{ matrix.configuration == 'Release' }}
@@ -68,7 +78,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./Files-${{ matrix.configuration }}.zip
+        asset_path: Files-${{ matrix.configuration }}.zip
         asset_name: Files-${{ matrix.configuration }}.zip
         asset_content_type: application/zip
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -51,6 +51,7 @@ jobs:
       run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
     - name: Create Draft Release
+      if: ${{ matrix.configuration == 'Release' }}
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -62,6 +63,7 @@ jobs:
         prerelease: false
 
     - uses: actions/upload-release-asset@v1.0.1
+      if: ${{ matrix.configuration == 'Release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -71,6 +73,7 @@ jobs:
         asset_content_type: application/zip
 
     - uses: eregon/publish-release@v1
+      if: ${{ matrix.configuration == 'Release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Release]  # TODO: add debug back here
+        configuration: [Debug, Release]  # TODO: add debug back here
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln
@@ -70,7 +70,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: holos4 # ${{ github.sha }}
+        tag_name: ${{ github.event.repository.updated_at }}
         release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -38,7 +38,7 @@ jobs:
         Configuration: ${{ matrix.configuration }}
 
     - name: Run Tests
-      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel
+      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
 
     - name: Upload build artifacts

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug]  # TODO: add release back here
+        configuration: [Release]  # TODO: add debug back here
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "testing" ]
+    branches: [ "testing" ]     # TODO: add main back here
   pull_request:
     branches: [ "main" ]
 
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug]
+        configuration: [Debug]  # TODO: add release back here
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln
@@ -40,10 +40,38 @@ jobs:
     - name: Run Tests
       run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
+    # - name: Upload build artifacts
+    #   if: ${{ matrix.configuration == 'Release' }}
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: Files-${{ matrix.configuration }}
+    #     path: '**/*/bin/*'
 
-    - name: Upload build artifacts
-      if: ${{ matrix.configuration == 'Release' }}
-      uses: actions/upload-artifact@v4
+    - name: Set current date as env variable
+      run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
+
+    - name: Create Draft Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: Files-${{ matrix.configuration }}
-        path: '**/*/bin/*'
+        tag_name: ${{ github.sha }}
+        release_name: Holos 4 - $NOW
+        draft: true
+        prerelease: false
+
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./Files-Release.zip
+        asset_name: Files-Release.zip
+        asset_content_type: application/zip
+
+    - uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "testing" ]     # TODO: add main back here
+    branches: [ "main" ]     # TODO: add main back here
   pull_request:
     branches: [ "main" ]
 
@@ -37,8 +37,8 @@ jobs:
       env:
         Configuration: ${{ matrix.configuration }}
 
-    # - name: Run Tests
-    #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
+    - name: Run Tests
+      run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
     - name: Upload build artifacts
       if: ${{ matrix.configuration == 'Release' }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]     # TODO: add main back here
+    branches: [ "testing" ]
   pull_request:
     branches: [ "main" ]
 
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug, Release]  # TODO: add debug back here
+        configuration: [Debug, Release]
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln
@@ -70,6 +70,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        tag_name: ${{ github.ref }}
         release_name: Holos 4 - ${{ github.event.repository.updated_at }}
         draft: true
         prerelease: false

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,21 +40,18 @@ jobs:
     # - name: Run Tests
     #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
-    - name: Upload build artifacts
-      if: ${{ matrix.configuration == 'Release' }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Holos4-lib
-        path: '**/H.Core/bin/*'
+    # - name: Upload build artifacts
+    #   if: ${{ matrix.configuration == 'Release' }}
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: Holos4-lib
+    #     path: '**/H.Core/bin/*'
 
-  release:
-    needs: build
-    runs-on:  windows-2019 # TODO: might be able to use ubuntu here
-    steps:
-    - name: "Download build"
-      uses: actions/download-artifact@v4
+    - uses: vimtor/action-zip@v1.2
+      if: ${{ matrix.configuration == 'Release' }}
       with:
-        name: Holos4-lib
+        files: H.Core/bin/
+        dest: Holos4-lib.zip
 
     - name: list directory (DEBUGGING)
       run: ls
@@ -77,8 +74,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Files-${{ matrix.configuration }}.zip
-        asset_name: Files-${{ matrix.configuration }}.zip
+        asset_path: Holos4-lib.zip
+        asset_name: Holos4-lib.zip
         asset_content_type: application/zip
 
     - uses: eregon/publish-release@v1

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,23 +40,22 @@ jobs:
     # - name: Run Tests
     #   run: vstest.console.exe ./**/bin/${{ matrix.configuration }}/H.*.Test.dll /Parallel /InIsolation
 
-    - name: list directory (DEBUGGING)
-      run: ls
-
     - name: Upload build artifacts
       if: ${{ matrix.configuration == 'Release' }}
       uses: actions/upload-artifact@v4
       with:
-        name: Files-${{ matrix.configuration }}
-        path: '**/*/bin/*'
-        
-    - name: list directory (DEBUGGING)
-      run: ls
+        name: Holos4-lib
+        path: '**/H.Core/bin/*'
 
   release:
     needs: build
     runs-on:  windows-2019 # TODO: might be able to use ubuntu here
     steps:
+    - name: "Download build"
+      uses: actions/download-artifact@v4
+      with:
+        name: Holos4-lib
+
     - name: list directory (DEBUGGING)
       run: ls
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "testing" ]
   pull_request:
     branches: [ "main" ]
 
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        configuration: [Debug]
     runs-on:  windows-2019
     env:
       Solution_Name: Holos.sln

--- a/.github/workflows/dotnet-pr-build.yml
+++ b/.github/workflows/dotnet-pr-build.yml
@@ -2,7 +2,7 @@ name: '[PR] Build and Test'
 
 on:
   pull_request:
-    branches: [ "pr-test" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet-pr-build.yml
+++ b/.github/workflows/dotnet-pr-build.yml
@@ -1,0 +1,11 @@
+name: '[PR] Build and Test'
+
+on:
+  pull_request:
+    branches: [ "pr-test" ]
+
+jobs:
+  build:
+    uses: ./dotnet-build-template.yml
+    with:
+      configuration: Debug

--- a/.github/workflows/dotnet-pr-build.yml
+++ b/.github/workflows/dotnet-pr-build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
-    uses: ./dotnet-build-template.yml
+    uses: ./.github/workflows/_dotnet-build-template.yml
     with:
       configuration: Debug
+      solution: Holos.sln

--- a/Holos.sln
+++ b/Holos.sln
@@ -23,7 +23,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{DDD11503
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_actions", "_actions", "{77B16CA8-F32F-4CA8-9F81-D556AC481930}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\dotnet-build.yml = .github\workflows\dotnet-build.yml
+		.github\workflows\dotnet-build-publish.yml = .github\workflows\dotnet-build-publish.yml
+		.github\workflows\dotnet-pr-build.yml = .github\workflows\dotnet-pr-build.yml
+		.github\workflows\_dotnet-build-template.yml = .github\workflows\_dotnet-build-template.yml
+		.github\workflows\_dotnet-publish-template.yml = .github\workflows\_dotnet-publish-template.yml
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
A couple of things happening here.

- One action that triggers on a PR. This builds and runs tests (in debug configuration) as a check to ensure bad code isn't merged into main branch.
- A second action has been added that triggers on pushes to main branch. This will happen after a PR is completed. This will again run the build and tests (in release configuration), but will additionally create artifacts and publish those as a GitHub release. This makes it easy to download the DLLs if someone wants to include them in their project (like AgExpert does).