### PR TITLE
Fix action failing due to api key

### DIFF
--- a/.github/workflows/_dotnet-nuget-template.yml
+++ b/.github/workflows/_dotnet-nuget-template.yml
@@ -10,7 +10,7 @@ jobs:
   reusable_workflow_job:
     runs-on:  windows-latest
     env:
-        NUGET_AUTH_TOKEN: ${{ secrets.HOLOS_ACTION_SECRET }}
+        NUGET_AUTH_TOKEN: ${{ secrets.HOLOS_NUGET_KEY }}
     steps:
     
     - name: Get date/time

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish new release
 
 on:
   push:
-    branches: [ "feature/nuget-org-packaging" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/H.Infrastructure.Test/KmlHelpersTest.cs
+++ b/H.Infrastructure.Test/KmlHelpersTest.cs
@@ -44,7 +44,6 @@ namespace H.Infrastructure.Test
         {
         }
 
-        [Ignore]
         [TestMethod]
         public void TestGetPolygonFromCoordinateAlberta()
         {
@@ -61,7 +60,6 @@ namespace H.Infrastructure.Test
             Assert.AreEqual(3.5, firstSoil.ProportionOfSoilOrganicCarbon);
         }
 
-        [Ignore]
         [TestMethod]
         public void TestGetPolygonFromCoordinateBC()
         {
@@ -79,7 +77,6 @@ namespace H.Infrastructure.Test
             Assert.AreEqual(1.31, firstSoil.BulkDensity);
         }
 
-        [Ignore]
         [TestMethod]
         public void TestGetPolygonFromCoordinateInvalid()
         {


### PR DESCRIPTION
This pull request should:
 
- Fix the error with the API key error resulting in the workflow to fail. 
- Reset actions to only run after changes are made to main branch.