### PR TITLE
Update Table_7_Relative_Biomass_Information.csv

### DIFF
--- a/H.Content/Resources/Table_7_Relative_Biomass_Information.csv
+++ b/H.Content/Resources/Table_7_Relative_Biomass_Information.csv
@@ -100,5 +100,6 @@ Perennial forages,Rangeland (native),Canada,13,,0.233,0,0.465,0.302,Bolinder et 
 ,Tame mixed,Canada,13,,0.298,0,0.426,0.277,Bolinder et al. (2007),,15,15,15,Little et al. (2008),,0.061,,,,,
 ,Seeded grassland,Canada,13,,0.317,0,0.414,0.269,Little et al. (2008),,15,15,15,Janzen et al. (2003),,0.049,,,,,
 ,Forage for seed,Canada,13,,0.1,0.392,0.308,0.2,Perenial forages (Bolinder et al. 2007),,30,15,13,Janzen et al. (2003),,0.049,,,,,
+,Grazed pasture (all perennial types),Canada,80,,,,,,Approximate mid-point of values from www.ontario.ca (75% MC in dry year, 80% MC in normal year, 85% MC in wet year), madbarn.ca (70-80% MC) and fieldcropnews.com (70-85% MC),,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,
 Trees,Total tree fruits & nuts,Canada,84,,,,,,,,2,10,10,Janzen et al. (2003),,,,,,,


### PR DESCRIPTION
Added row to specify default 80% MC value for all grazed perennial forages. This value can be applied to all perennial forage types when grazing animals are present on a specific field in a specific year. For each forage type, all other values remain the same for that type.