### PR TITLE
Set default assignee in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,8 @@
 name: Bug/Issue Report
 description: File a bug or report an issue with Holos.
 labels: ["bug"]
+assignees:
+  - holos-aafc
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,8 @@
 name: Feature Request
 description: Submit a request for a feature you would like to see in Holos.
 labels: ["feature request"]
+assignees:
+  - holos-aafc
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/suggestion-code.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion-code.yml
@@ -2,7 +2,7 @@ name: Code Suggestion
 description: Suggest a change to the Holos source code.
 labels: ["suggestion", "code"]
 assignees:
-  - hafzaal
+  - holos-aafc
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/suggestion-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion-documentation.yml
@@ -2,7 +2,7 @@ name: Holos Documentation Suggestion
 description: Suggest a change to the Holos documentation.
 labels: ["suggestion", "documentation"]
 assignees:
-  - hafzaal
+  - holos-aafc
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR will set user `holos-aafc` as the default assignee for newly created issues.