### PR TITLE
Python scripts for translation data entry and cli example inputs converted to markdown

### DIFF
--- a/H.Content/Scripts/excelFileForCLIToMarkdown.py
+++ b/H.Content/Scripts/excelFileForCLIToMarkdown.py
@@ -1,0 +1,57 @@
+import openpyxl
+
+# This script reads from 
+
+# Set these parameters to your own values
+xlsxFilePath = r"C:\Users\ExampleUser\Documents\CLI_Parameters.xlsx"
+outputMarkdownFileName = "OutputMarkdown.md"
+
+workbook = openpyxl.load_workbook(xlsxFilePath)
+
+# Create a markdown file or write to existing file
+with open(outputMarkdownFileName, "a") as f:
+
+    # Iterate through sheets in xlsx file
+    for sheet in workbook.worksheets:
+
+        # Get last populated row, openpyxl does not have a method that does this correctly
+        lastPopulatedRow = 0
+        for row in range(sheet.max_row, 0, -1):
+            if any(cell.value is not None for cell in sheet[row]):
+                lastPopulatedRow = row
+                break
+
+        # Write the header of the markdown file
+        f.write("\n<br>\n\n")
+        f.write("# " + sheet.title + "\n")
+
+        for i in range (1, lastPopulatedRow+1):
+            for j in range (1, sheet.max_column+1):
+                
+                # Removes zeros appended to integers when read from xlsx file
+                value = (str(sheet.cell(i,j).value) + " ").replace(".0 ", "")
+                # Replaces "None" with empty string
+                if (value == "None "):
+                    value = ""
+                
+                if (i == 1):
+                    break
+                elif (j == 1):
+                    f.write("## " + str(sheet.cell(i,j).value).replace(" ", "") + "\n\n")
+                elif (j == 2):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                elif (j == 3):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                elif (j == 4):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                elif (j == 5):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                elif (j == 6):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                elif (j == 7):
+                    f.write(str(sheet.cell(1,j+1).value) + ": " + value + "\n\n")
+                    f.write("***\n")
+
+                    
+                
+    

--- a/H.Content/Scripts/translationsFromExcelToResx.py
+++ b/H.Content/Scripts/translationsFromExcelToResx.py
@@ -1,0 +1,51 @@
+import openpyxl
+from lxml import etree
+# Must use lxml in order to preserve comments and namespaces in the XML file (pip install lxml)
+
+# Assign these variables to correct file paths and to the correct sheet name in the Excel file
+resxFilePath = r"C:\Users\ExampleUser\source\repos\Holos\H\H.Core\Properties\Resources.fr-CA.resx"
+xlsxFilePath = r"C:\Users\ExampleUser\Documents\Resources.xlsx"
+excelFileSheetName = 'H.Core Resources.resx'
+
+def readTranslatedValues(xlsxFilePath):
+    translatedValues = {}
+
+    # Load correct sheet from Excel file
+    workbook = openpyxl.load_workbook(xlsxFilePath)
+    sheet = workbook[excelFileSheetName]
+
+    # Iterate through the rows in the sheet and extract the key and translated value
+    # Assumes french column is the third column (index 2) and the key is in the first column (index 0)
+    for row in sheet.iter_rows(values_only=True):
+        key = row[0]
+        translatedValues[key] = row[2]
+
+    return translatedValues
+
+def enterTranslatedValuesToResx(resxFilePath, translatedValues):
+    matchedElements = []
+
+    parser = etree.XMLParser(remove_blank_text=False)
+    tree = etree.parse(resxFilePath, parser)
+    root = tree.getroot()
+    resxData = root.findall('.//data')
+
+    # Iterate through the data elements and update the value if the key matches
+    for keys in resxData:
+        name = keys.get('name')
+        if name in translatedValues:
+            frenchTranslation = keys.find('value')      
+            if frenchTranslation is not None:
+                frenchTranslation.text = "translatedValues[name]"
+                matchedElements.append(name)
+
+    # Print elements from Excel file that did not match any elements in the .resx file, usually a slight mispelling of the key in the .resx file
+    invalidElements = set(translatedValues)-set(matchedElements)
+    print(f"This entries did not have match in the resx file: {invalidElements}")
+
+    # Save the updated .resx file, preserving comments and namespaces
+    tree.write(resxFilePath, encoding='utf-8', xml_declaration=True, pretty_print=True)
+
+if __name__ == "__main__":
+    translatedValues = readTranslatedValues(xlsxFilePath)
+    enterTranslatedValuesToResx(resxFilePath, translatedValues)


### PR DESCRIPTION
excelFileForCLIToMarkdown.py converts the example data from the Excel file for the CLI in to a readable markdown format.

translationsFromExcelToResx.py imports the translation values received from translation services and inputs them back in to the French resources file if there are matching keys. Will also highlight discrepancies in keys between the Excel file and Resx file to ensure no translated values are missed.