### PR TITLE
Make FinalSettings method virtual and override in derived classes

### DIFF
--- a/H.CLI/Interfaces/IComponentTemporaryInput.cs
+++ b/H.CLI/Interfaces/IComponentTemporaryInput.cs
@@ -17,8 +17,11 @@ namespace H.CLI.Interfaces
         #endregion
 
         #region Methods
+
         void ConvertToComponentProperties(string key, ImperialUnitsOfMeasurement? units, string value, int row, int col, string filePath);
+
         void InputDataReflectionHandler(PropertyInfo propertyInfo, ImperialUnitsOfMeasurement? units, string prop, string value, string filePath, int col, int row);
+
         /// <summary>
         /// If the user uses an old CSV component file that is missing some headers then this function will input default values instead.
         /// </summary>
@@ -26,6 +29,5 @@ namespace H.CLI.Interfaces
         void FinalSettings(IComponentKeys componentKeys);
 
         #endregion
-
     }
 }

--- a/H.CLI/Parser/Parser.cs
+++ b/H.CLI/Parser/Parser.cs
@@ -134,6 +134,7 @@ namespace H.CLI.Parser
                 else
                     continue;
             }
+
             //Checks all files and their list of temporary component objects
             _errorHandler.CheckIfComponentsHaveTheSameName(fileToComponentPairList);
 
@@ -142,6 +143,7 @@ namespace H.CLI.Parser
             return parsedComponentList;
 
         }
+
         #endregion
     }
 }

--- a/H.CLI/Properties/Resources.resx
+++ b/H.CLI/Properties/Resources.resx
@@ -1505,5 +1505,7 @@ Would you like to continue using this directory?</value>
   <data name="Key_PercentageOfExtrarootsReturnedToSoil" xml:space="preserve">`
       <value>PercentageOfExtrarootsReturnedToSoil</value>
   </data>
-</root>
+  <data name="FarmsDirectoryName" xml:space="preserve">`r`n    <value>Farms</value>`r`n  </data>`r`n  <data name="FarmNameSeparator" xml:space="preserve">`r`n    <value>_</value>`r`n  </data>`r`n  <data name="VersionPrefix" xml:space="preserve">`r`n    <value> (</value>`r`n  </data>`r`n  <data name="VersionSuffix" xml:space="preserve">`r`n    <value>)</value>`r`n  </data>`r`n</root>
+
+
 

--- a/H.CLI/TemporaryComponentStorage/FieldTemporaryInput.cs
+++ b/H.CLI/TemporaryComponentStorage/FieldTemporaryInput.cs
@@ -430,7 +430,7 @@ namespace H.CLI.TemporaryComponentStorage
         /// This method sets default values for properties when these values were not provided in the input data but are required for calculations.
         /// </summary>
         /// <param name="componentKeys">The component keys configuration that indicates which headers were missing from the input data</param>
-        public void FinalSettings(IComponentKeys componentKeys)
+        public override void FinalSettings(IComponentKeys componentKeys)
         {
             if (componentKeys.MissingHeaders.ContainsKey(Properties.Resources.Key_NitrogenFixation) && componentKeys.MissingHeaders[Properties.Resources.Key_NitrogenFixation])
             {
@@ -449,6 +449,7 @@ namespace H.CLI.TemporaryComponentStorage
                 this.PercentageOfExtrarootsReturnedToSoil = _initializationService.GetDefaultPercentageExtrarootReturnedToSoil();
             }
         }
+
         #endregion
 
         /*
@@ -457,7 +458,6 @@ namespace H.CLI.TemporaryComponentStorage
          *
          * NOTE: Ensure property names match exactly with the keys in FieldKeys.cs
          */
-
 
         #region Properties
 

--- a/H.CLI/TemporaryComponentStorage/ShelterBeltTemporaryInput.cs
+++ b/H.CLI/TemporaryComponentStorage/ShelterBeltTemporaryInput.cs
@@ -123,9 +123,10 @@ namespace H.CLI.TemporaryComponentStorage
                 propertyInfo.SetValue(this, Convert.ChangeType(value, propertyInfo.PropertyType, CLILanguageConstants.culture), null);
         }
 
-        public void FinalSettings(IComponentKeys componentKeys)
+        public override void FinalSettings(IComponentKeys componentKeys)
         {
         }
+
         #endregion
 
         //When adding a new property, follow the format: NewProperty. If you add a new property here, make sure to add the
@@ -152,8 +153,6 @@ namespace H.CLI.TemporaryComponentStorage
         public string GroupName { get; set; }
         public AnimalType GroupType { get; set; }
         #endregion
-
-
     }
 }
 

--- a/H.CLI/TemporaryComponentStorage/TemporaryInputBase.cs
+++ b/H.CLI/TemporaryComponentStorage/TemporaryInputBase.cs
@@ -75,7 +75,7 @@ namespace H.CLI.TemporaryComponentStorage
             }
         }
 
-        public void FinalSettings(IComponentKeys componentKeys)
+        public virtual void FinalSettings(IComponentKeys componentKeys)
         {
         }
 


### PR DESCRIPTION
Changed FinalSettings in TemporaryInputBase to virtual and updated FieldTemporaryInput and ShelterBeltTemporaryInput to override it. This allows derived classes to provide specific implementations for setting default values when input data is missing. Also made minor formatting and whitespace adjustments, and added new resource strings to Resources.resx.