### PR TITLE
Update perennial stand root input calculation logic

### DIFF
--- a/H.CLI/H.CLI.csproj
+++ b/H.CLI/H.CLI.csproj
@@ -37,7 +37,7 @@
     <ProductName>Holos 4 CLI</ProductName>
     <PublisherName>AAFC-AAC</PublisherName>
     <SuiteName>Holos</SuiteName>
-    <MinimumRequiredVersion>1.0.1.51</MinimumRequiredVersion>
+    <MinimumRequiredVersion>1.0.1.52</MinimumRequiredVersion>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <AutorunEnabled>true</AutorunEnabled>
     <ApplicationRevision>52</ApplicationRevision>

--- a/H.Core/Calculators/Carbon/ICBMCarbonInputCalculator.cs
+++ b/H.Core/Calculators/Carbon/ICBMCarbonInputCalculator.cs
@@ -409,8 +409,10 @@ namespace H.Core.Calculators.Carbon
 
             // Equation 2.1.2-28
             var carbonInputFromRoots = carbonInput * (currentYearViewItem.PercentageOfRootsReturnedToSoil / 100.0);
-            if (currentYearViewItem.YearInPerennialStand == 1)
+            if (currentYearViewItem.YearInPerennialStand == 1 || currentYearViewItem.IsFinalYearInPerennialStand())
             {
+                // If we are in the final year of the perennial stand, or the first year, we do not consider the previous year's root inputs and do not apply any increase (e.g. Equation 2.1.2-30)
+
                 return carbonInputFromRoots;
             }
 


### PR DESCRIPTION
Modified ICBMCarbonInputCalculator to also exclude previous year's root inputs in the final year of a perennial stand, not just the first year. Updated CLI project minimum required version and application revision to 1.0.1.52 and 52 respectively.