### PR TITLE
Fix bug where GetMonthFromJulianDay() would sometimes return the inco…

### DIFF
--- a/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
+++ b/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using H.Core.Enumerations;
+﻿using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.LandManagement.Fields;
 using H.Core.Services.LandManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace H.Core.Test.Services.LandManagement
 {
@@ -46,10 +46,10 @@ namespace H.Core.Test.Services.LandManagement
         [TestMethod]
         public void GetTotalDailyPrecipitationTest()
         {
-           var result = _sut.GetTotalDailyPrecipitation(5, 6, Province.Manitoba, 2021, 100);
+            var result = _sut.GetTotalDailyPrecipitation(5, 6, Province.Manitoba, 2021, 100);
 
-           // Should be equal to precipitation since no irrigation is used in January
-           Assert.AreEqual(6, result);
+            // Should be equal to precipitation since no irrigation is used in January
+            Assert.AreEqual(6, result);
         }
 
         [TestMethod]
@@ -62,8 +62,8 @@ namespace H.Core.Test.Services.LandManagement
                 dailyPrecipitation.Add(10);
             }
 
-            var farm = new Farm() {Province = Province.BritishColumbia};
-            var crop = new CropViewItem() {AmountOfIrrigation = 50, Year = 2017};
+            var farm = new Farm() { Province = Province.BritishColumbia };
+            var crop = new CropViewItem() { AmountOfIrrigation = 50, Year = 2017 };
 
             var result = _sut.AddIrrigationToDailyPrecipitations(dailyPrecipitation, farm, crop);
 
@@ -88,19 +88,41 @@ namespace H.Core.Test.Services.LandManagement
             foreach (var d in result)
             {
                 // Get month
-                var month = _sut.GetMonthFromJulianDay(julianDay);
+                var month = _sut.GetMonthFromJulianDay(julianDay, crop.Year);
                 var percentage = table[month];
 
 
                 var precipitation = dailyPrecipitation.ElementAt(julianDay - 1);
-                
-                var totalPrecipitation = _sut.GetTotalDailyPrecipitation(julianDay, precipitation, farm.Province,crop.Year, crop.AmountOfIrrigation);
-                var expected = precipitation + ( crop.AmountOfIrrigation * (percentage / 100.0) / DateTime.DaysInMonth(crop.Year, (int)month));
+
+                var totalPrecipitation = _sut.GetTotalDailyPrecipitation(julianDay, precipitation, farm.Province, crop.Year, crop.AmountOfIrrigation);
+                var expected = precipitation + (crop.AmountOfIrrigation * (percentage / 100.0) / DateTime.DaysInMonth(crop.Year, (int)month));
 
                 Assert.AreEqual(expected, totalPrecipitation);
 
                 julianDay++;
             }
+        }
+
+        [DataTestMethod]
+        [DataRow(1, 2021, Months.January)]
+        [DataRow(31, 2021, Months.January)]
+        [DataRow(32, 2021, Months.February)]
+        [DataRow(59, 2021, Months.February)]
+        [DataRow(60, 2021, Months.March)]
+        [DataRow(90, 2021, Months.March)]
+        [DataRow(91, 2021, Months.April)]
+        [DataRow(213, 2021, Months.August)]
+        [DataRow(243, 2021, Months.August)]
+        [DataRow(335, 2021, Months.December)]
+        [DataRow(365, 2021, Months.December)]
+        [DataRow(32, 2024, Months.February)]
+        [DataRow(60, 2024, Months.February)] // day 60 is usually March, but in leap year it's still February
+        [DataRow(91, 2024, Months.March)] // day 91 is usually April, but in leap year it's still March
+        [DataRow(366, 2024, Months.December)] // should be invalid in most years, but not in leap years
+        public void GetMonthFromJulianDayTest(int julianDay, int year, Months expectedMonth)
+        {
+            var result = _sut.GetMonthFromJulianDay(julianDay, year);
+            Assert.AreEqual(expectedMonth, result);
         }
     }
 }

--- a/H.Core/Services/LandManagement/IrrigationService.cs
+++ b/H.Core/Services/LandManagement/IrrigationService.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Media;
-using H.Core.Enumerations;
+﻿using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.LandManagement.Fields;
-using H.Core.Providers.Climate;
 using H.Core.Providers.Irrigation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace H.Core.Services.LandManagement
 {
@@ -15,7 +13,7 @@ namespace H.Core.Services.LandManagement
         #region Fields
 
         private readonly Table_4_Monthly_Irrigation_Water_Application_Provider _irrigationProvider = new Table_4_Monthly_Irrigation_Water_Application_Provider();
-        
+
 
         #endregion
 
@@ -85,28 +83,7 @@ namespace H.Core.Services.LandManagement
         /// </summary>
         public double GetTotalDailyPrecipitation(int julianDay, double precipitation, Province province, int year, double annualIrrigation)
         {
-            var month = this.GetMonthFromJulianDay(julianDay);
-
-            double irrigationPercentage = 0;
-            var data = _irrigationProvider.GetMonthlyAverageIrrigationDataInstance(month, province);
-            if (data != null)
-            {
-                irrigationPercentage = data.IrrigationVolume;
-            }
-
-            // Lookup value will be null for January, February, March, November, and December
-
-            var fraction = irrigationPercentage / 100.0;
-            double daysInMonth = DateTime.DaysInMonth(year, (int) month);
-
-            var result = precipitation + ((annualIrrigation * fraction) / daysInMonth);
-
-            return result;
-        }
-
-        public double GetIrrigationForDay(int julianDay, Province province, int year, double annualIrrigation)
-        {
-            var month = this.GetMonthFromJulianDay(julianDay);
+            var month = this.GetMonthFromJulianDay(julianDay, year);
 
             double irrigationPercentage = 0;
             var data = _irrigationProvider.GetMonthlyAverageIrrigationDataInstance(month, province);
@@ -120,13 +97,34 @@ namespace H.Core.Services.LandManagement
             var fraction = irrigationPercentage / 100.0;
             double daysInMonth = DateTime.DaysInMonth(year, (int)month);
 
-            var result =  ((annualIrrigation * fraction) / daysInMonth);
+            var result = precipitation + ((annualIrrigation * fraction) / daysInMonth);
+
+            return result;
+        }
+
+        public double GetIrrigationForDay(int julianDay, Province province, int year, double annualIrrigation)
+        {
+            var month = this.GetMonthFromJulianDay(julianDay, year);
+
+            double irrigationPercentage = 0;
+            var data = _irrigationProvider.GetMonthlyAverageIrrigationDataInstance(month, province);
+            if (data != null)
+            {
+                irrigationPercentage = data.IrrigationVolume;
+            }
+
+            // Lookup value will be null for January, February, March, November, and December
+
+            var fraction = irrigationPercentage / 100.0;
+            double daysInMonth = DateTime.DaysInMonth(year, (int)month);
+
+            var result = ((annualIrrigation * fraction) / daysInMonth);
 
             return result;
         }
 
         public List<double> AddIrrigationToDailyPrecipitations(
-            List<double> dailyPrecipitationList, 
+            List<double> dailyPrecipitationList,
             Farm farm,
             CropViewItem cropViewItem)
         {
@@ -137,10 +135,10 @@ namespace H.Core.Services.LandManagement
             foreach (var dailyPrecipitation in dailyPrecipitationList)
             {
                 var dailyPrecipitationAndIrrigation = this.GetTotalDailyPrecipitation(
-                    julianDay, 
+                    julianDay,
                     dailyPrecipitation,
-                    farm.Province, 
-                    cropViewItem.Year, 
+                    farm.Province,
+                    cropViewItem.Year,
                     cropViewItem.AmountOfIrrigation);
 
                 result.Add(dailyPrecipitationAndIrrigation);
@@ -151,60 +149,16 @@ namespace H.Core.Services.LandManagement
             return result;
         }
 
-        public Months GetMonthFromJulianDay(int julianDay)
+        public Months GetMonthFromJulianDay(int julianDay, int year)
         {
-            if (julianDay >= 1 && julianDay <= 31)
-            {
-                return Months.January;
-            }
-            else if (julianDay >= 32 && julianDay <= 59)
-            {
-                return Months.February;
-            }
-            else if (julianDay >= 60 && julianDay <= 90)
-            {
-                return Months.March;
-            }
-            else if (julianDay >= 91 && julianDay <= 120)
-            {
-                return Months.April;
-            }
-            else if (julianDay >= 121 && julianDay <= 151)
-            {
-                return Months.May;
-            }
-            else if (julianDay >= 152 && julianDay <= 181)
-            {
-                return Months.June;
-            }
-            else if (julianDay >= 182 && julianDay <= 212)
-            {
-                return Months.July;
-            }
-            else if (julianDay >= 213 && julianDay <= 243)
-            {
-                return Months.August;
-            }
-            else if (julianDay >= 244 && julianDay <= 273)
-            {
-                return Months.September;
-            }
-            else if (julianDay >= 274 && julianDay <= 304)
-            {
-                return Months.October;
-            }
-            else if (julianDay >= 305 && julianDay <= 334)
-            {
-                return Months.November;
-            }
-            else if (julianDay >= 335 && julianDay <= 366) // Include 366 to account for leap years
-            {
-                return Months.December;
-            }
-            else
+            if (julianDay > (DateTime.IsLeapYear(year) ? 366 : 365))
             {
                 throw new Exception($"Julian day out of range: {julianDay}");
             }
+
+            return (Months)new DateTime(year, 1, 1)
+                .AddDays(julianDay - 1) // Get datetime for the julian day
+                .Month; // Extract month from datetime
         }
 
         #endregion


### PR DESCRIPTION
There appears to be a bug in the `GetMonthFromJulianDay()` method in the `IrrigationService.cs`. It does not take into account whether a year is a leap year, and always assumes that February is 28 days long. This results in first-day of months being considered the incorrect month during leap years.

During non-leap years the 60th day of the year is March 1st. But during leap years the 60th day of the year is February 29th. See image below. The same issue persists throughout the year for any month after February.

<img width="272" height="91" alt="image" src="https://github.com/user-attachments/assets/a734c63d-02e7-47be-8274-f9fc149a9ec0" />

This PR uses the internal `DateTime` class to figure out what month a day is, then casts the result directly to the `Month` enumerable value.