### PR TITLE
Remove AutoMapper dependency (CVE-2026-32933)

### DIFF
--- a/H.Core.Test/H.Core.Test.csproj
+++ b/H.Core.Test/H.Core.Test.csproj
@@ -185,6 +185,7 @@
     </Compile>
     <Compile Include="ResultConversionClassTests.cs" />
     <Compile Include="Services\Animals\DigestateServiceTest.cs" />
+    <Compile Include="Mappers\AutoMapperCharacterizationTest.cs" />
     <Compile Include="Services\Animals\ManureRemovalVolatileSolidsTest.cs" />
     <Compile Include="Services\Animals\ScaleUpServiceTest.cs" />
     <Compile Include="Services\Animals\AnimalInitializationServiceTest.cs" />

--- a/H.Core.Test/Mappers/AutoMapperCharacterizationTest.cs
+++ b/H.Core.Test/Mappers/AutoMapperCharacterizationTest.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using H.Core.Mappers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace H.Core.Test.Mappers
+{
+    /// <summary>
+    /// Locks the clone contract that Holos relied on from AutoMapper's same-type <c>CreateMap&lt;T,T&gt;</c> maps and
+    /// that <see cref="PropertyMapper"/> must reproduce after AutoMapper is removed (CVE-2026-32933). Two layers:
+    ///
+    ///   1. Precise engine-contract tests on a small synthetic type (scalar copy, shared complex reference, new
+    ///      collection container with the same elements, per-call ignore set including Guid).
+    ///   2. Parity tests that clone the real hot domain types through BOTH AutoMapper 9 and <see cref="PropertyMapper"/>
+    ///      and assert they agree member-by-member. These are the ~14 type-level locks.
+    /// </summary>
+    [TestClass]
+    public class AutoMapperCharacterizationTest
+    {
+        #region Layer 1 - engine contract on a synthetic type
+
+        private class Leaf
+        {
+            public string Tag { get; set; }
+        }
+
+        private class DerivedNode : Node
+        {
+            public string SubclassOnly { get; set; }
+        }
+
+        private class Node
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+            public DayOfWeek Day { get; set; }
+            public Guid Guid { get; set; }
+            public Leaf Child { get; set; }
+            public ObservableCollection<Leaf> Items { get; set; } = new ObservableCollection<Leaf>();
+        }
+
+        private static Node SampleNode()
+        {
+            var node = new Node { Name = "n1", Count = 7, Day = DayOfWeek.Friday, Guid = Guid.NewGuid(), Child = new Leaf { Tag = "c" } };
+            node.Items.Add(new Leaf { Tag = "a" });
+            node.Items.Add(new Leaf { Tag = "b" });
+            return node;
+        }
+
+        [TestMethod]
+        public void Clone_CopiesScalarsStringAndEnum()
+        {
+            var src = SampleNode();
+            var clone = PropertyMapper.Clone(src);
+
+            Assert.AreEqual("n1", clone.Name);
+            Assert.AreEqual(7, clone.Count);
+            Assert.AreEqual(DayOfWeek.Friday, clone.Day);
+        }
+
+        [TestMethod]
+        public void Clone_SharesComplexReference()
+        {
+            var src = SampleNode();
+            var clone = PropertyMapper.Clone(src);
+
+            Assert.IsNotNull(clone.Child);
+            Assert.IsTrue(ReferenceEquals(src.Child, clone.Child), "complex member must be shared by reference, not deep-copied");
+        }
+
+        [TestMethod]
+        public void Clone_Collection_IsNewContainer_WithSameElementReferences()
+        {
+            var src = SampleNode();
+            var clone = PropertyMapper.Clone(src);
+
+            Assert.IsFalse(ReferenceEquals(src.Items, clone.Items), "collection must be a NEW container, not the same list reference");
+            Assert.AreEqual(src.Items.Count, clone.Items.Count);
+            Assert.IsTrue(ReferenceEquals(src.Items[0], clone.Items[0]), "collection elements must be the SAME references (shallow)");
+
+            // Mutating the clone's container must not affect the source list (proves de-aliasing of the container).
+            clone.Items.Clear();
+            Assert.AreEqual(2, src.Items.Count, "clearing the clone's list must not touch the source list");
+        }
+
+        [TestMethod]
+        public void Clone_WithoutIgnore_CopiesGuid()
+        {
+            var src = SampleNode();
+            var clone = PropertyMapper.Clone(src);
+            Assert.AreEqual(src.Guid, clone.Guid, "Guid is copied when not ignored");
+        }
+
+        [TestMethod]
+        public void Clone_IgnoresNamedProperties_IncludingGuidAndCollection()
+        {
+            var src = SampleNode();
+            var clone = PropertyMapper.Clone(src, nameof(Node.Guid), nameof(Node.Items));
+
+            Assert.AreEqual(Guid.Empty, clone.Guid, "ignored Guid must be left at default");
+            Assert.AreEqual(0, clone.Items.Count, "ignored collection must be left at the constructor default (empty)");
+            Assert.AreEqual("n1", clone.Name, "non-ignored members are still copied");
+        }
+
+        [TestMethod]
+        public void CopyTo_OntoExisting_OverwritesNonIgnored_LeavesIgnored()
+        {
+            var src = SampleNode();
+            var dest = new Node { Name = "OLD", Count = 1, Guid = Guid.NewGuid() };
+            var destGuid = dest.Guid;
+
+            PropertyMapper.CopyTo(src, dest, nameof(Node.Guid));
+
+            Assert.AreEqual("n1", dest.Name);
+            Assert.AreEqual(7, dest.Count);
+            Assert.AreEqual(destGuid, dest.Guid, "ignored Guid on an existing instance is preserved");
+            Assert.IsTrue(ReferenceEquals(src.Child, dest.Child));
+        }
+
+        [TestMethod]
+        public void Clone_SourceIsSubclassOfDeclaredType_MapsAsDeclaredType_DoesNotThrow()
+        {
+            // Mirrors ClimateData.BarnTemperatureData: a property typed as the base holds a subclass instance. Cloning
+            // must map it as the declared (base) type - like AutoMapper's CreateMap<Base,Base> - not throw on the
+            // subclass-only members.
+            Node source = new DerivedNode { Name = "d", Count = 3, Child = new Leaf { Tag = "c" }, SubclassOnly = "x" };
+
+            var clone = PropertyMapper.Clone(source); // T inferred as Node (declared), runtime is DerivedNode
+
+            Assert.AreEqual("d", clone.Name);
+            Assert.AreEqual(3, clone.Count);
+            Assert.AreEqual(typeof(Node), clone.GetType(), "clone is the declared type; subclass-only members are dropped, matching AutoMapper");
+        }
+
+        #endregion
+
+        #region Layer 2 - parity with AutoMapper over the real hot types
+
+        // The same-type clone maps with un-ignored collection/complex members (from the removal inventory).
+        private static readonly string[] HotTypes =
+        {
+            "CropViewItem", "Farm", "Diet", "FeedIngredient",
+            "ManureApplicationViewItem", "DigestateApplicationViewItem", "FertilizerApplicationViewItem",
+            "ClimateData", "ManagementPeriod", "HousingDetails", "FieldSystemComponent",
+            "AnaerobicDigestionComponent", "ManureSubstrateViewItem", "SubstrateFlowInformation",
+        };
+
+        private static Assembly CoreAssembly => typeof(H.Core.Services.Animals.ManureService).Assembly;
+
+        [TestMethod]
+        public void PropertyMapper_CloneContract_OnHotTypes()
+        {
+            // The clone contract PropertyMapper must uphold on the real domain types (originally established by parity
+            // against AutoMapper, which has since been removed): complex reference members are SHARED; collection members
+            // become a NEW container holding the SAME elements.
+            var typesByName = CoreAssembly.GetTypes().GroupBy(t => t.Name).ToDictionary(g => g.Key, g => g.First());
+            var failures = new List<string>();
+            var checkedTypes = 0;
+
+            foreach (var name in HotTypes)
+            {
+                if (!typesByName.TryGetValue(name, out var type))
+                {
+                    failures.Add($"{name}: TYPE NOT FOUND");
+                    continue;
+                }
+
+                object source;
+                try { source = Activator.CreateInstance(type); }
+                catch (Exception e) { failures.Add($"{name}: cannot construct ({Root(e).GetType().Name})"); continue; }
+
+                var populated = Populate(type, source);
+                if (populated.Count == 0)
+                {
+                    continue; // nothing reference-typed to check on this type
+                }
+
+                object pmClone;
+                try
+                {
+                    pmClone = Activator.CreateInstance(type);
+                    PropertyMapper.CopyProperties(source, pmClone, type); // map by the concrete type; no ignores = maximal exposure
+                }
+                catch (Exception e) { failures.Add($"{name}: PropertyMapper.CopyProperties threw ({Root(e).GetType().Name})"); continue; }
+
+                foreach (var (prop, srcVal, isColl) in populated)
+                {
+                    var pmVal = prop.GetValue(pmClone);
+
+                    if (isColl)
+                    {
+                        // A collection becomes a NEW container (not the source list) with the SAME element count and
+                        // elements (same reference for reference-type elements, equal value for enum/value-type elements).
+                        if (pmVal == null) { failures.Add($"{name}.{prop.Name}: produced a null collection"); continue; }
+                        if (ReferenceEquals(pmVal, srcVal)) { failures.Add($"{name}.{prop.Name}: shared the collection reference (aliasing)"); continue; }
+
+                        var s = ToList(srcVal); var p = ToList(pmVal);
+                        if (p.Count != s.Count) { failures.Add($"{name}.{prop.Name}: count {p.Count} != source {s.Count}"); continue; }
+                        for (var i = 0; i < s.Count; i++)
+                        {
+                            if (!ElementEquivalent(s[i], p[i])) { failures.Add($"{name}.{prop.Name}[{i}]: element not equivalent to source"); break; }
+                        }
+                    }
+                    else
+                    {
+                        // A complex reference member is shared (assigned by reference, not deep-copied).
+                        if (!ReferenceEquals(pmVal, srcVal)) { failures.Add($"{name}.{prop.Name}: did not share the complex reference"); }
+                    }
+                }
+
+                checkedTypes++;
+            }
+
+            Assert.IsTrue(checkedTypes >= 10, $"Expected to check the hot types; only {checkedTypes} were checked.");
+            Assert.AreEqual(0, failures.Count, "PropertyMapper clone-contract violations:\n  " + string.Join("\n  ", failures));
+        }
+
+        // The bundle deep-copy behaviour that FarmResultsService (Farm, ClimateData) and FieldComponentHelper (fertilizer)
+        // relied on was characterized against AutoMapper and is documented in the removal notes; those services now
+        // reproduce it with explicit clone loops, guarded by the real ReplicateFarm/Replicate integration tests.
+
+        #endregion
+
+        #region helpers
+
+        private static List<(PropertyInfo Prop, object Value, bool IsColl)> Populate(Type type, object target)
+        {
+            var populated = new List<(PropertyInfo, object, bool)>();
+            foreach (var p in Writable(type))
+            {
+                if (p.Name == "Guid") continue;
+                var isColl = IsCollection(p.PropertyType);
+                var isComplex = !p.PropertyType.IsValueType && p.PropertyType != typeof(string);
+                if (!isColl && !isComplex) continue;
+
+                var val = isColl ? MakeCollection(p.PropertyType) : TryMake(p.PropertyType);
+                if (val == null) continue;
+                try { p.SetValue(target, val); populated.Add((p, val, isColl)); } catch { }
+            }
+            return populated;
+        }
+
+        private static IEnumerable<PropertyInfo> Writable(Type t) =>
+            t.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0);
+
+        private static bool IsCollection(Type t) => typeof(IEnumerable).IsAssignableFrom(t) && t != typeof(string);
+
+        private static object TryMake(Type t) { try { return Activator.CreateInstance(t); } catch { return null; } }
+
+        private static object MakeCollection(Type t)
+        {
+            try
+            {
+                var concrete = (t.IsInterface || t.IsAbstract) && t.IsGenericType
+                    ? typeof(List<>).MakeGenericType(t.GetGenericArguments()[0]) : t;
+                var instance = Activator.CreateInstance(concrete);
+                if (instance is IList list && t.IsGenericType)
+                {
+                    var item = TryMake(t.GetGenericArguments()[0]);
+                    if (item != null) { try { list.Add(item); } catch { } }
+                }
+                return instance;
+            }
+            catch { return null; }
+        }
+
+        private static List<object> ToList(object enumerable)
+        {
+            var list = new List<object>();
+            foreach (var x in (IEnumerable)enumerable) list.Add(x);
+            return list;
+        }
+
+        private static bool ElementEquivalent(object a, object b)
+        {
+            if (a == null && b == null) return true;
+            if (a == null || b == null) return false;
+            return a.GetType().IsValueType ? a.Equals(b) : ReferenceEquals(a, b);
+        }
+
+        private static Exception Root(Exception e) => e.InnerException == null ? e : Root(e.InnerException);
+
+        #endregion
+    }
+}

--- a/H.Core/Calculators/Infrastructure/ADCalculator.cs
+++ b/H.Core/Calculators/Infrastructure/ADCalculator.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using H.Core.Models.Animals;
 using H.Core.Providers.AnaerobicDigestion;
 using System.ComponentModel;
-using AutoMapper;
 using H.Core.Providers.Climate;
 using H.Core.Models.LandManagement.Fields;
 using H.Core.Services.Animals;
@@ -23,8 +22,6 @@ namespace H.Core.Calculators.Infrastructure
         #region Fields
 
         
-        private readonly IMapper _substrateMapper;
-
         protected readonly Table_47_Solid_Liquid_Separation_Coefficients_Provider
             _solidLiquidSeparationCoefficientsProvider = new Table_47_Solid_Liquid_Separation_Coefficients_Provider();
 
@@ -37,14 +34,6 @@ namespace H.Core.Calculators.Infrastructure
 
         public ADCalculator()
         {
-            var substrateFlowMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<SubstrateFlowInformation, SubstrateFlowInformation>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
-
-            _substrateMapper = substrateFlowMapperConfiguration.CreateMapper();
         }
 
         #endregion

--- a/H.Core/Calculators/Nitrogen/N2OEmissionFactorCalculator.Grazing.cs
+++ b/H.Core/Calculators/Nitrogen/N2OEmissionFactorCalculator.Grazing.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Transactions;
 using System.Windows.Media.Animation;
-using AutoMapper.Configuration.Annotations;
 using H.Core.Events;
 using H.Core.Models.LandManagement.Fields;
 using H.Core.Providers.Animals;

--- a/H.Core/Enumerations/ImperialUnitsOfMeasurement.cs
+++ b/H.Core/Enumerations/ImperialUnitsOfMeasurement.cs
@@ -1,4 +1,3 @@
-﻿using AutoMapper;
 using H.Core.Properties;
 using H.Infrastructure;
 

--- a/H.Core/H.Core.csproj
+++ b/H.Core/H.Core.csproj
@@ -267,6 +267,8 @@
     <Compile Include="Enumerations\YieldAssignmentMethod.cs" />
     <Compile Include="Events\FarmResultsCalculatedEvent.cs" />
     <Compile Include="Events\FarmResultsCalculatedEventArgs.cs" />
+    <Compile Include="Mappers\ModelMapper.cs" />
+    <Compile Include="Mappers\PropertyMapper.cs" />
     <Compile Include="Models\AdjoiningYears.cs" />
     <Compile Include="Models\Animals\AnimalComponentBase.cs" />
     <Compile Include="Models\Animals\AnimalGroup.cs" />
@@ -800,9 +802,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper">
-      <Version>9.0.0</Version>
-    </PackageReference>
     <PackageReference Include="CommonServiceLocator">
       <Version>2.0.7</Version>
     </PackageReference>

--- a/H.Core/Mappers/ModelMapper.cs
+++ b/H.Core/Mappers/ModelMapper.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace H.Core.Mappers
+{
+    /// <summary>
+    /// Thin adapter that replaces an AutoMapper <c>IMapper</c> built from a single same-type
+    /// <c>CreateMap&lt;T,T&gt;</c> plus an ignore set (and optional <c>ConstructUsing</c> factory). It holds the ignore
+    /// set once (as the AutoMapper configuration did) and forwards to <see cref="PropertyMapper"/>, so existing call
+    /// sites keep their <c>Map(source)</c> / <c>Map(source, destination)</c> shape. Behaviour is verified against
+    /// AutoMapper by the mapper contract tests.
+    /// </summary>
+    public class ModelMapper<T> where T : new()
+    {
+        private readonly string[] _ignoredProperties;
+        private readonly Func<T> _factory;
+
+        public ModelMapper(params string[] ignoredProperties)
+            : this(null, ignoredProperties)
+        {
+        }
+
+        /// <summary>
+        /// Overload for maps that used <c>ConstructUsing</c> with a non-default constructor (e.g.
+        /// <c>new EvapotranspirationData(false)</c>). The factory builds the destination for the <see cref="Map(T)"/>
+        /// (clone) overload.
+        /// </summary>
+        public ModelMapper(Func<T> factory, params string[] ignoredProperties)
+        {
+            _factory = factory;
+            _ignoredProperties = ignoredProperties ?? new string[0];
+        }
+
+        /// <summary>Creates a new <typeparamref name="T"/> from <paramref name="source"/> (replaces <c>Map&lt;T&gt;(source)</c>).</summary>
+        public T Map(T source)
+        {
+            if (source == null)
+            {
+                return default(T);
+            }
+
+            var destination = _factory != null ? _factory() : new T();
+            PropertyMapper.CopyTo(source, destination, _ignoredProperties);
+            return destination;
+        }
+
+        /// <summary>
+        /// Copies <paramref name="source"/> onto the existing <paramref name="destination"/> and returns it (replaces
+        /// AutoMapper's <c>Map(source, destination)</c>, which also returns the destination).
+        /// </summary>
+        public T Map(T source, T destination)
+        {
+            PropertyMapper.CopyTo(source, destination, _ignoredProperties);
+            return destination;
+        }
+    }
+}

--- a/H.Core/Mappers/PropertyMapper.cs
+++ b/H.Core/Mappers/PropertyMapper.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace H.Core.Mappers
+{
+    /// <summary>
+    /// Convention-based, same-type object copier that reproduces the behaviour Holos relied on from AutoMapper's
+    /// same-type <c>CreateMap&lt;T,T&gt;</c> clones, without the AutoMapper dependency (removes CVE-2026-32933).
+    ///
+    /// Behaviour is defined by characterization against AutoMapper 9 (see the mapper contract tests):
+    ///   - a scalar / string / enum property is copied by value;
+    ///   - a collection property becomes a <b>new container of the same runtime type holding the same element
+    ///     references</b> (a shallow list copy - new list, same items);
+    ///   - any other reference-type ("complex") property is assigned by <b>shared reference</b> (not deep-copied);
+    ///   - properties named in the per-call ignore set are left untouched. Note <c>Guid</c> is <b>not</b> special-cased
+    ///     here (unlike the Holos v5 mapper): call sites that need to preserve identity pass "Guid" in the ignore set,
+    ///     exactly as they passed <c>ForMember(x =&gt; x.Guid, o =&gt; o.Ignore())</c> to AutoMapper.
+    ///
+    /// This copier is non-recursive by construction, so it cannot reintroduce the uncontrolled-recursion DoS that
+    /// motivated removing AutoMapper.
+    /// </summary>
+    public static class PropertyMapper
+    {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _propertyCache =
+            new ConcurrentDictionary<Type, PropertyInfo[]>();
+
+        /// <summary>
+        /// Creates a new <typeparamref name="T"/> and copies all non-ignored matching properties from
+        /// <paramref name="source"/> onto it.
+        /// </summary>
+        public static T Clone<T>(T source, params string[] ignoredProperties) where T : new()
+        {
+            if (source == null)
+            {
+                return default(T);
+            }
+
+            var destination = new T();
+            CopyTo(source, destination, ignoredProperties);
+            return destination;
+        }
+
+        /// <summary>
+        /// Copies all non-ignored matching properties from <paramref name="source"/> onto the existing
+        /// <paramref name="destination"/> instance.
+        /// </summary>
+        public static void CopyTo<T>(T source, T destination, params string[] ignoredProperties)
+        {
+            // Copy the properties of the DECLARED map type T (not the runtime type). AutoMapper's CreateMap<T,T> maps
+            // exactly T's properties, so if a base-typed map is applied to derived instances (e.g. AnimalComponentBase),
+            // only the base properties are copied - and a subclass-only property is never applied to a base destination.
+            CopyProperties(source, destination, typeof(T), ignoredProperties);
+        }
+
+        /// <summary>
+        /// Copies the writable properties of <paramref name="mapType"/> from <paramref name="source"/> onto
+        /// <paramref name="destination"/> (both must be assignable to <paramref name="mapType"/>). This is the engine
+        /// behind <see cref="CopyTo{T}"/>; call it directly when the map type is only known at runtime.
+        /// </summary>
+        public static void CopyProperties(object source, object destination, Type mapType, params string[] ignoredProperties)
+        {
+            if (source == null || destination == null)
+            {
+                return;
+            }
+
+            HashSet<string> ignore = null;
+            if (ignoredProperties != null && ignoredProperties.Length > 0)
+            {
+                ignore = new HashSet<string>(ignoredProperties);
+            }
+
+            foreach (var property in GetCopyableProperties(mapType))
+            {
+                if (ignore != null && ignore.Contains(property.Name))
+                {
+                    continue;
+                }
+
+                var value = property.GetValue(source);
+                if (value == null)
+                {
+                    // Leave the destination's default in place rather than overwriting with null.
+                    continue;
+                }
+
+                if (IsCollection(property.PropertyType))
+                {
+                    // New container, same elements. If it cannot be reconstructed, fall back to sharing the reference.
+                    var rewrapped = CopyCollectionShallow(value);
+                    property.SetValue(destination, rewrapped ?? value);
+                }
+                else
+                {
+                    // Scalars/enums copied by value; complex reference types assigned by shared reference.
+                    property.SetValue(destination, value);
+                }
+            }
+        }
+
+        private static PropertyInfo[] GetCopyableProperties(Type type)
+        {
+            return _propertyCache.GetOrAdd(type, t => t
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0)
+                .ToArray());
+        }
+
+        private static bool IsCollection(Type type)
+        {
+            return typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
+        }
+
+        /// <summary>
+        /// Returns a new collection of the same runtime type as <paramref name="source"/>, holding the same element
+        /// references (shallow). Covers <see cref="IList"/> and <see cref="IDictionary"/> - i.e. ObservableCollection,
+        /// List and Dictionary. Returns null if the collection type has no usable parameterless constructor or is an
+        /// unsupported shape, so the caller can fall back to sharing the original reference.
+        /// </summary>
+        private static object CopyCollectionShallow(object source)
+        {
+            var type = source.GetType();
+
+            object instance;
+            try
+            {
+                instance = Activator.CreateInstance(type);
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (instance is IList list)
+            {
+                foreach (var item in (IEnumerable)source)
+                {
+                    list.Add(item);
+                }
+
+                return list;
+            }
+
+            if (instance is IDictionary dictionary)
+            {
+                foreach (DictionaryEntry entry in (IDictionary)source)
+                {
+                    dictionary.Add(entry.Key, entry.Value);
+                }
+
+                return dictionary;
+            }
+
+            return null;
+        }
+    }
+}

--- a/H.Core/Models/Animals/HousingDetails.cs
+++ b/H.Core/Models/Animals/HousingDetails.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Converters;
 using H.Core.CustomAttributes;
 using H.Core.Enumerations;
@@ -36,7 +36,8 @@ namespace H.Core.Models.Animals
 
         private string _nameOfPastureLocation;
 
-        private static readonly IMapper _housingDetailsMapper;
+        private static readonly ModelMapper<HousingDetails> _housingDetailsMapper =
+            new ModelMapper<HousingDetails>(nameof(HousingDetails.Guid), nameof(HousingDetails.Name));
 
         private bool _useCustomIndoorHousingTemperature;
 
@@ -44,17 +45,6 @@ namespace H.Core.Models.Animals
 
         #region Constructors
 
-        static HousingDetails()
-        {
-            var housingDetailsConfiguration = new MapperConfiguration(config =>
-            {
-                config.CreateMap<HousingDetails, HousingDetails>()
-                    .ForMember(housingDetails => housingDetails.Guid, opt => opt.Ignore())
-                    .ForMember(housingDetails => housingDetails.Name, opt => opt.Ignore());
-            });
-
-            _housingDetailsMapper = housingDetailsConfiguration.CreateMapper();
-        }
         public HousingDetails()
         {
             this.GrazingSystemType = null; // No grazing by default
@@ -243,7 +233,7 @@ namespace H.Core.Models.Animals
 
         public static HousingDetails CopyHousingDetails(HousingDetails sourceHousingDetails)
         {
-            var copyHousingDetails = _housingDetailsMapper.Map<HousingDetails>(sourceHousingDetails);
+            var copyHousingDetails = _housingDetailsMapper.Map(sourceHousingDetails);
 
             return copyHousingDetails;
         }

--- a/H.Core/Models/Animals/ManagementPeriod.cs
+++ b/H.Core/Models/Animals/ManagementPeriod.cs
@@ -1,6 +1,5 @@
 ﻿#region Imports
 
-using AutoMapper;
 using H.Core.Converters;
 using H.Core.CustomAttributes;
 using H.Core.Enumerations;

--- a/H.Core/Models/Animals/ManureDetails.cs
+++ b/H.Core/Models/Animals/ManureDetails.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Converters;
 using H.Core.CustomAttributes;
 using H.Core.Enumerations;
@@ -42,21 +42,11 @@ namespace H.Core.Models.Animals
         private bool _useCustomVolatilizationFraction;
         private bool _useCustomMethaneConversionFactor;
 
-        private static IMapper _manureDetailsMapper;
+        private static readonly ModelMapper<ManureDetails> _manureDetailsMapper =
+            new ModelMapper<ManureDetails>(nameof(ManureDetails.Guid), nameof(ManureDetails.Name));
         #endregion
 
         #region Constructors
-
-        static ManureDetails()
-        {
-            var manureDetailsMapperConfiguration = new MapperConfiguration(config =>
-            {
-                config.CreateMap<ManureDetails, ManureDetails>()
-                    .ForMember(manureDetails => manureDetails.Guid, opt => opt.Ignore())
-                    .ForMember(manureDetails => manureDetails.Name, opt => opt.Ignore());
-            });
-            _manureDetailsMapper = manureDetailsMapperConfiguration.CreateMapper();
-        }
 
         public ManureDetails()
         {
@@ -360,7 +350,7 @@ namespace H.Core.Models.Animals
 
         public static ManureDetails CopyManureDetails(ManureDetails manureDetailsToCopy)
         {
-            return _manureDetailsMapper.Map<ManureDetails>(manureDetailsToCopy);
+            return _manureDetailsMapper.Map(manureDetailsToCopy);
         }
 
         /// <summary>

--- a/H.Core/Models/Farm.cs
+++ b/H.Core/Models/Farm.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using System.Security.Permissions;
 using System.Windows.Controls.Primitives;
 using System.Windows.Navigation;
-using AutoMapper.Configuration.Conventions;
 using H.Core.Models.Animals;
 using H.Core.Converters;
 using H.Core.Emissions.Results;

--- a/H.Core/Providers/Animals/Table_44_Fraction_OrganicN_Mineralized_As_Tan_Provider.cs
+++ b/H.Core/Providers/Animals/Table_44_Fraction_OrganicN_Mineralized_As_Tan_Provider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using AutoMapper.Configuration.Conventions;
 using H.Core.Enumerations;
 using H.Core.Tools;
 using H.Infrastructure;

--- a/H.Core/Providers/Economics/CropEconomicsProvider.cs
+++ b/H.Core/Providers/Economics/CropEconomicsProvider.cs
@@ -8,7 +8,7 @@ using H.Content;
 using H.Core.Converters;
 using H.Core.Enumerations;
 using H.Infrastructure;
-using AutoMapper;
+using H.Core.Mappers;
 
 namespace H.Core.Providers.Economics
 {
@@ -78,8 +78,7 @@ namespace H.Core.Providers.Economics
         public CropEconomicData Get(CropType cropType, SoilFunctionalCategory soilFunctionalCategory, Province province)
         {
             //we need a deep copy of the econ data
-            var config = new MapperConfiguration(cfg => cfg.CreateMap<CropEconomicData, CropEconomicData>());
-            var mapper = config.CreateMapper();
+            var mapper = new ModelMapper<CropEconomicData>();
 
             var soilCategory = soilFunctionalCategory.GetBaseSoilFunctionalCategory();
 
@@ -196,7 +195,7 @@ namespace H.Core.Providers.Economics
         /// <param name="mapper">the mapper</param>
         /// <returns>CropEconomicData matching the search but from another province</returns>
         private CropEconomicData GetMatchInNeighbouringProvince(Province province, CropType originalCropType,
-            SoilFunctionalCategory soilCategory, IMapper mapper)
+            SoilFunctionalCategory soilCategory, ModelMapper<CropEconomicData> mapper)
         {
             const int searchLimit = 2;
 
@@ -234,7 +233,7 @@ namespace H.Core.Providers.Economics
                 }
             }
 
-            var result = mapper.Map<CropEconomicData>(econData);
+            var result = mapper.Map(econData);
             return result;
         }
 
@@ -242,7 +241,7 @@ namespace H.Core.Providers.Economics
         /// Cycle through all of the soil zones in the province and try and find economic data for the croptype
         /// </summary>
         private CropEconomicData GetMatchAcrossTheProvince(Province province, CropType econCropType,
-            SoilFunctionalCategory soilFunctionalCategory, IMapper mapper)
+            SoilFunctionalCategory soilFunctionalCategory, ModelMapper<CropEconomicData> mapper)
         {
             if (soilFunctionalCategory == SoilFunctionalCategory.NotApplicable) return new CropEconomicData();
             CropEconomicData econData = null;
@@ -260,7 +259,7 @@ namespace H.Core.Providers.Economics
                 soilNeighbour = soilNeighbour.GetNeighbouringCategory();
             }
 
-            var result = mapper.Map<CropEconomicData>(econData);
+            var result = mapper.Map(econData);
             return result;
 
         }
@@ -269,7 +268,7 @@ namespace H.Core.Providers.Economics
         /// Get economic data that matches directly to province, soil zone, and croptype
         /// </summary>
         private CropEconomicData GetDirectMatch(CropType cropType, Province province,
-            SoilFunctionalCategory soilCategory, CropType econCropType, IMapper mapper)
+            SoilFunctionalCategory soilCategory, CropType econCropType, ModelMapper<CropEconomicData> mapper)
         {
             CropEconomicData result;
             if (soilCategory == SoilFunctionalCategory.Brown && province == Province.Alberta &&
@@ -280,7 +279,7 @@ namespace H.Core.Providers.Economics
                     entry.CropType == CropType.SummerFallow &&
                     entry.SoilFunctionalCategory == soilCategory &&
                     entry.Province == province);
-                result = mapper.Map<CropEconomicData>(econData);
+                result = mapper.Map(econData);
             }
             else if (cropType == CropType.Fallow || cropType == CropType.SummerFallow)
             {
@@ -289,7 +288,7 @@ namespace H.Core.Providers.Economics
                     entry.CropType == econCropType &&
                     entry.SoilFunctionalCategory == SoilFunctionalCategory.NotApplicable &&
                     entry.Province == province);
-                result = mapper.Map<CropEconomicData>(econData);
+                result = mapper.Map(econData);
             }
             else
             {
@@ -298,7 +297,7 @@ namespace H.Core.Providers.Economics
                     entry.CropType == econCropType &&
                     entry.SoilFunctionalCategory == soilCategory &&
                     entry.Province == province);
-                result = mapper.Map<CropEconomicData>(econData);
+                result = mapper.Map(econData);
             }
 
             return result;

--- a/H.Core/Providers/Feed/Diet.cs
+++ b/H.Core/Providers/Feed/Diet.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Transactions;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Converters;
 using H.Core.CustomAttributes;
 using H.Core.Enumerations;
@@ -51,32 +51,14 @@ namespace H.Core.Providers.Feed
         private EntericMethanEmissionMethodologies _selectedMethaneEmissionMethodology;
 
         private ObservableCollection<FeedIngredient> _ingredients;
-        private static MapperConfiguration _dietMapperConfiguration;
-        private static MapperConfiguration _ingredientMapperConfiguration;
-        private static IMapper _dietMapper;
-        private static IMapper _ingredientMapper;
+        private static readonly ModelMapper<Diet> _dietMapper =
+            new ModelMapper<Diet>(nameof(Diet.Ingredients));
+        private static readonly ModelMapper<FeedIngredient> _ingredientMapper =
+            new ModelMapper<FeedIngredient>(nameof(FeedIngredient.Guid));
 
         #endregion
 
         #region Constructors
-
-        static Diet()
-        {
-            _dietMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<Diet, Diet>().ForMember(property => property.Ingredients, options => options.Ignore());
-            });
-
-            _ingredientMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<FeedIngredient, FeedIngredient>()
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
-
-            _dietMapper = _dietMapperConfiguration.CreateMapper();
-
-            _ingredientMapper = _ingredientMapperConfiguration.CreateMapper();
-        }
 
         public Diet()
         {
@@ -500,7 +482,7 @@ namespace H.Core.Providers.Feed
 
             foreach (var feedIngredient in ingredientsToBeCopied)
             {
-                var copiedIngredient = _ingredientMapper.Map<FeedIngredient>(feedIngredient);
+                var copiedIngredient = _ingredientMapper.Map(feedIngredient);
 
                 copiedDiet.Ingredients.Add(copiedIngredient);
             }

--- a/H.Core/Providers/Feed/DietProvider.cs
+++ b/H.Core/Providers/Feed/DietProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using AutoMapper;
 using H.Core.Enumerations;
 using H.Core.Properties;
 using H.Core.Providers.Animals;

--- a/H.Core/Providers/Feed/FeedIngredient.cs
+++ b/H.Core/Providers/Feed/FeedIngredient.cs
@@ -1,7 +1,7 @@
 ﻿#region Imports
 
 using System;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Calculators.UnitsOfMeasurement;
 using H.Core.CustomAttributes;
 using H.Core.Enumerations;
@@ -201,21 +201,13 @@ namespace H.Core.Providers.Feed
         private double _pufa;
         private double _iv;
         private double _ivp;
-        private static IMapper _ingredientMapper;
+        private static readonly ModelMapper<FeedIngredient> _ingredientMapper =
+            new ModelMapper<FeedIngredient>(nameof(FeedIngredient.Guid));
 
         #endregion
 
         #region Constructors
 
-        static FeedIngredient()
-        {
-            var mapperConfig = new MapperConfiguration(x =>
-            {
-                x.CreateMap<FeedIngredient, FeedIngredient>().ForMember(prop => prop.Guid, opt => opt.Ignore());
-            });
-            _ingredientMapper = mapperConfig.CreateMapper();
-
-        }
         #endregion
 
         #region Properties
@@ -1329,7 +1321,7 @@ namespace H.Core.Providers.Feed
 
         public static FeedIngredient CopyFeedIngredient(FeedIngredient ingredient)
         {
-            return _ingredientMapper.Map<FeedIngredient>(ingredient);
+            return _ingredientMapper.Map(ingredient);
         }
 
         public static FeedIngredient ConvertFeedIngredientToImperial(FeedIngredient ingredient)

--- a/H.Core/Providers/Feed/FeedIngredientProvider.cs
+++ b/H.Core/Providers/Feed/FeedIngredientProvider.cs
@@ -7,7 +7,7 @@ using H.Content;
 using H.Core.Converters;
 using H.Infrastructure;
 using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Enumerations;
 
 #endregion
@@ -25,7 +25,7 @@ namespace H.Core.Providers.Feed
         private readonly IList<FeedIngredient> _dairyIngredients;
         private readonly IList<FeedIngredient> _swineFeedIngredients;
         
-        private readonly IMapper _feedIngredientMapper;
+        private readonly ModelMapper<FeedIngredient> _feedIngredientMapper;
 
         #endregion
 
@@ -37,12 +37,7 @@ namespace H.Core.Providers.Feed
             _dairyIngredients = this.ReadDairyFile().ToList();
             _swineFeedIngredients = this.ReadSwineFile().ToList();
 
-            var feedIngredientMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<FeedIngredient, FeedIngredient>();
-            });
-
-            _feedIngredientMapper = feedIngredientMapper.CreateMapper();
+            _feedIngredientMapper = new ModelMapper<FeedIngredient>();
         }
 
         #endregion

--- a/H.Core/Providers/Fertilizer/Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider.cs
+++ b/H.Core/Providers/Fertilizer/Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Content;
 using H.Core.Converters;
 using H.Core.Enumerations;
@@ -18,7 +18,7 @@ namespace H.Core.Providers.Fertilizer
 
         private readonly FertilizerBlendConverter _converter = new FertilizerBlendConverter();
         private readonly List<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data> _cache = new List<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data>();
-        private readonly IMapper _blendMapper;
+        private readonly ModelMapper<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data> _blendMapper;
 
         #endregion
 
@@ -26,13 +26,8 @@ namespace H.Core.Providers.Fertilizer
 
         public Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider()
         {
-            var configuration = new MapperConfiguration(expression =>
-            {
-                expression.CreateMap<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data, Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data>()
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
-
-            _blendMapper = configuration.CreateMapper();
+            _blendMapper = new ModelMapper<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data>(
+                nameof(Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data.Guid));
 
             _cache.AddRange(this.BuildCache());
         }
@@ -62,7 +57,7 @@ namespace H.Core.Providers.Fertilizer
             var cachedItem = _cache.SingleOrDefault(item => item.FertilizerBlend == blend);
             if (cachedItem != null)
             {
-                return _blendMapper.Map<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data>(cachedItem);
+                return _blendMapper.Map(cachedItem);
             }
             else
             {

--- a/H.Core/Services/AnaerobicDigestionComponentHelper.cs
+++ b/H.Core/Services/AnaerobicDigestionComponentHelper.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+﻿using H.Core.Mappers;
 using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.Animals;
@@ -17,13 +17,13 @@ namespace H.Core.Services
     {
         #region Fields
 
-        private readonly IMapper _anaerobicDigestionComponentMapper;
-        private readonly IMapper _anaerobicDigestionViewItemMapper;
-        private readonly IMapper _animalGroupMapper;
-        private readonly IMapper _cropResiduesSubstrateViewItemMapper;
-        private readonly IMapper _farmResiduesSubstrateViewItemMapper;
-        private readonly IMapper _manureSubstrateViewItemMapper;
-        private readonly IMapper _managementPeriodViewItemsMapper;
+        private readonly ModelMapper<AnaerobicDigestionComponent> _anaerobicDigestionComponentMapper;
+        private readonly ModelMapper<AnaerobicDigestionViewItem> _anaerobicDigestionViewItemMapper;
+        private readonly ModelMapper<AnimalGroup> _animalGroupMapper;
+        private readonly ModelMapper<CropResidueSubstrateViewItem> _cropResiduesSubstrateViewItemMapper;
+        private readonly ModelMapper<FarmResiduesSubstrateViewItem> _farmResiduesSubstrateViewItemMapper;
+        private readonly ModelMapper<ManureSubstrateViewItem> _manureSubstrateViewItemMapper;
+        private readonly ModelMapper<ADManagementPeriodViewItem> _managementPeriodViewItemsMapper;
 
         #endregion
 
@@ -31,48 +31,35 @@ namespace H.Core.Services
 
         public AnaerobicDigestionComponentHelper()
         {
-            var anaerobicDigestionComponentMapperConfiguration = new MapperConfiguration(x =>
-                x.CreateMap<AnaerobicDigestionComponent, AnaerobicDigestionComponent>()
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.CurrentPeriodComponentGuid, z => z.Ignore())
-                    .ForMember(y => y.AnaerobicDigestionViewItem, z => z.Ignore())
-                    .ForMember(y => y.ManagementPeriodViewItems, z => z.Ignore()));
-            _anaerobicDigestionComponentMapper = anaerobicDigestionComponentMapperConfiguration.CreateMapper();
+            _anaerobicDigestionComponentMapper = new ModelMapper<AnaerobicDigestionComponent>(
+                nameof(AnaerobicDigestionComponent.Guid),
+                nameof(AnaerobicDigestionComponent.CurrentPeriodComponentGuid),
+                nameof(AnaerobicDigestionComponent.AnaerobicDigestionViewItem),
+                nameof(AnaerobicDigestionComponent.ManagementPeriodViewItems));
 
-            var anaerobicDigestionViewItemMapperConfiguration = new MapperConfiguration(x =>
-                    x.CreateMap<AnaerobicDigestionViewItem, AnaerobicDigestionViewItem>()
-                .ForMember(y => y.Guid, z => z.Ignore())
-                .ForMember(y => y.CropResiduesSubstrateViewItems, z => z.Ignore())
-                .ForMember(y => y.FarmResiduesSubstrateViewItems, z => z.Ignore())
-                .ForMember(y => y.ManureSubstrateViewItems, z => z.Ignore()));
-            _anaerobicDigestionViewItemMapper = anaerobicDigestionViewItemMapperConfiguration.CreateMapper();
+            _anaerobicDigestionViewItemMapper = new ModelMapper<AnaerobicDigestionViewItem>(
+                nameof(AnaerobicDigestionViewItem.Guid),
+                nameof(AnaerobicDigestionViewItem.CropResiduesSubstrateViewItems),
+                nameof(AnaerobicDigestionViewItem.FarmResiduesSubstrateViewItems),
+                nameof(AnaerobicDigestionViewItem.ManureSubstrateViewItems));
 
-            var managementPeriodViewItemsMapperConfiguration = new MapperConfiguration(x =>
-                x.CreateMap<ADManagementPeriodViewItem, ADManagementPeriodViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.AnimalComponent, z => z.Ignore())
-                    .ForMember(y => y.AnimalGroup, z => z.Ignore())
-                    .ForMember(y => y.ManagementPeriod, z => z.Ignore()));
-            _managementPeriodViewItemsMapper = managementPeriodViewItemsMapperConfiguration.CreateMapper();
+            _managementPeriodViewItemsMapper = new ModelMapper<ADManagementPeriodViewItem>(
+                nameof(ADManagementPeriodViewItem.Guid),
+                nameof(ADManagementPeriodViewItem.AnimalComponent),
+                nameof(ADManagementPeriodViewItem.AnimalGroup),
+                nameof(ADManagementPeriodViewItem.ManagementPeriod));
 
-            var animalGroupMapperConfiguration = new MapperConfiguration(x => x.CreateMap<AnimalGroup, AnimalGroup>()
-                .ForMember(y => y.ManagementPeriods, z => z.Ignore()));
-            _animalGroupMapper = animalGroupMapperConfiguration.CreateMapper();
+            _animalGroupMapper = new ModelMapper<AnimalGroup>(
+                nameof(AnimalGroup.ManagementPeriods));
 
-            var cropResiduesSubstrateViewItemMapperConfiguration = new MapperConfiguration(x =>
-                x.CreateMap<CropResidueSubstrateViewItem, CropResidueSubstrateViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore()));
-            _cropResiduesSubstrateViewItemMapper = cropResiduesSubstrateViewItemMapperConfiguration.CreateMapper();
+            _cropResiduesSubstrateViewItemMapper = new ModelMapper<CropResidueSubstrateViewItem>(
+                nameof(CropResidueSubstrateViewItem.Guid));
 
-            var farmResiduesSubstrateViewItemMapperConfiguration = new MapperConfiguration(x =>
-                x.CreateMap<FarmResiduesSubstrateViewItem, FarmResiduesSubstrateViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore()));
-            _farmResiduesSubstrateViewItemMapper = farmResiduesSubstrateViewItemMapperConfiguration.CreateMapper();
+            _farmResiduesSubstrateViewItemMapper = new ModelMapper<FarmResiduesSubstrateViewItem>(
+                nameof(FarmResiduesSubstrateViewItem.Guid));
 
-            var manureSubstrateViewItemMapperConfiguration = new MapperConfiguration(x =>
-                x.CreateMap<ManureSubstrateViewItem, ManureSubstrateViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore()));
-            _manureSubstrateViewItemMapper = manureSubstrateViewItemMapperConfiguration.CreateMapper();
+            _manureSubstrateViewItemMapper = new ModelMapper<ManureSubstrateViewItem>(
+                nameof(ManureSubstrateViewItem.Guid));
         }
 
         #endregion

--- a/H.Core/Services/AnimalComponentHelper.cs
+++ b/H.Core/Services/AnimalComponentHelper.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.Animals;
@@ -20,8 +20,8 @@ namespace H.Core.Services
     {
         #region Fields
 
-        private readonly IMapper _animalGroupMapper;
-        private readonly IMapper _managementPeriodMapper;
+        private readonly ModelMapper<AnimalGroup> _animalGroupMapper;
+        private readonly ModelMapper<ManagementPeriod> _managementPeriodMapper;
         private readonly ITimePeriodHelper _timePeriodHelper = new TimePeriodHelper(); 
 
         #endregion
@@ -30,24 +30,14 @@ namespace H.Core.Services
 
         public AnimalComponentHelper()
         {
-            var animalGroupMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<AnimalGroup, AnimalGroup>()
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.ManagementPeriods, z => z.Ignore());
-            });
+            _animalGroupMapper = new ModelMapper<AnimalGroup>(
+                nameof(AnimalGroup.Guid),
+                nameof(AnimalGroup.ManagementPeriods));
 
-            _animalGroupMapper = animalGroupMapperConfiguration.CreateMapper();
-
-            var managementPeriodMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<ManagementPeriod, ManagementPeriod>()
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.HousingDetails, z => z.Ignore())
-                    .ForMember(y => y.ManureDetails, z => z.Ignore());
-            });
-
-            _managementPeriodMapper = managementPeriodMapperConfiguration.CreateMapper();
+            _managementPeriodMapper = new ModelMapper<ManagementPeriod>(
+                nameof(ManagementPeriod.Guid),
+                nameof(ManagementPeriod.HousingDetails),
+                nameof(ManagementPeriod.ManureDetails));
         }
 
         #endregion
@@ -171,14 +161,7 @@ namespace H.Core.Services
 
         public void ReplicateManureDetails(ManagementPeriod from, ManagementPeriod to)
         {
-            var configuration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<ManureDetails, ManureDetails>()
-                 .ForMember(y => y.Name, z => z.Ignore())
-                 .ForMember(y => y.Guid, z => z.Ignore());
-            });
-
-            var mapper = configuration.CreateMapper();
+            var mapper = new ModelMapper<ManureDetails>(nameof(ManureDetails.Name), nameof(ManureDetails.Guid));
 
             var manureDetails = new ManureDetails();
             mapper.Map(from.ManureDetails, manureDetails);
@@ -187,14 +170,7 @@ namespace H.Core.Services
 
         public void ReplicateHousingDetails(ManagementPeriod from, ManagementPeriod to)
         {
-            var configuration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<HousingDetails, HousingDetails>()
-                 .ForMember(y => y.Name, z => z.Ignore())
-                 .ForMember(y => y.Guid, z => z.Ignore());
-            });
-
-            var mapper = configuration.CreateMapper();
+            var mapper = new ModelMapper<HousingDetails>(nameof(HousingDetails.Name), nameof(HousingDetails.Guid));
 
             var housingDetails = new HousingDetails();
             mapper.Map(from.HousingDetails, housingDetails);

--- a/H.Core/Services/Animals/ManureService.cs
+++ b/H.Core/Services/Animals/ManureService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Emissions.Results;
 using H.Core.Enumerations;
 using H.Core.Models;
@@ -59,7 +59,7 @@ namespace H.Core.Services.Animals
             ManureLocationSourceType.Imported,
         };
 
-        private readonly IMapper _manureCompositionMapper;
+        private readonly ModelMapper<DefaultManureCompositionData> _manureCompositionMapper;
         private List<AnimalComponentEmissionsResults> _animalComponentEmissionsResults;
 
         #endregion
@@ -70,13 +70,8 @@ namespace H.Core.Services.Animals
         {
             _manureTanks = new List<ManureTank>();
 
-            var manureCompositionMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<DefaultManureCompositionData, DefaultManureCompositionData>()
-                    .ForMember(y => y.Guid, z => z.Ignore());
-            });
-
-            _manureCompositionMapper = manureCompositionMapperConfiguration.CreateMapper();
+            _manureCompositionMapper = new ModelMapper<DefaultManureCompositionData>(
+                nameof(DefaultManureCompositionData.Guid));
         }
 
         #endregion
@@ -894,7 +889,7 @@ namespace H.Core.Services.Animals
                     animalType: animalType);
 
                 // Make a copy
-                var mappedItem = _manureCompositionMapper.Map<DefaultManureCompositionData>(manureComposition);
+                var mappedItem = _manureCompositionMapper.Map(manureComposition);
 
                 return mappedItem;
             }

--- a/H.Core/Services/FarmHelper.cs
+++ b/H.Core/Services/FarmHelper.cs
@@ -4,7 +4,6 @@ using H.Core.Providers.Feed;
 using System;
 using System.Collections.ObjectModel;
 using H.Core.Services.Initialization;
-using AutoMapper;
 using System.Collections.Generic;
 
 namespace H.Core.Services

--- a/H.Core/Services/FarmResultsService.cs
+++ b/H.Core/Services/FarmResultsService.cs
@@ -6,8 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows.Navigation;
-using AutoMapper;
-using AutoMapper.Execution;
+using H.Core.Mappers;
 using H.Core.Calculators.Economics;
 using H.Core.Calculators.Infrastructure;
 using H.Core.Calculators.Nitrogen;
@@ -50,14 +49,14 @@ namespace H.Core.Services
         private readonly IAnimalService _animalResultsService;
         private readonly IADCalculator _adCalculator;
 
-        private readonly IMapper _farmMapper;
-        private readonly IMapper _defaultsMapper;
-        private readonly IMapper _detailsScreenCropViewItemMapper;
-        private readonly IMapper _dailyClimateDataMapper;
-        private readonly IMapper _soilDataMapper;
-        private readonly IMapper _customYieldDataMapper;
-        private readonly IMapper _climateDataMapper;
-        private readonly IMapper _geographicDataMapper;
+        private readonly ModelMapper<Farm> _farmMapper;
+        private readonly ModelMapper<Defaults> _defaultsMapper;
+        private readonly ModelMapper<CropViewItem> _detailsScreenCropViewItemMapper;
+        private readonly ModelMapper<DailyClimateData> _dailyClimateDataMapper;
+        private readonly ModelMapper<SoilData> _soilDataMapper;
+        private readonly ModelMapper<CustomUserYieldData> _customYieldDataMapper;
+        private readonly ModelMapper<ClimateData> _climateDataMapper;
+        private readonly ModelMapper<GeographicData> _geographicDataMapper;
 
         private readonly IEventAggregator _eventAggregator;
 
@@ -124,100 +123,35 @@ namespace H.Core.Services
                 throw new ArgumentNullException(nameof(eventAggregator));
             }
 
-            #region Farm Mapping
+            #region Mappers
 
-            var farmMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<Farm, Farm>()
-                    .ForMember(y => y.Name, z => z.Ignore())
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.Defaults, z => z.Ignore())
-                    .ForMember(y => y.StageStates, z => z.Ignore())
-                    .ForMember(y => y.ClimateData, z => z.Ignore())
-                    .ForMember(y => y.GeographicData, z => z.Ignore())
-                    .ForMember(y => y.Components, z => z.Ignore());
+            // Farm's Diets / DefaultManureCompositionData / DefaultsCompositionOfBeddingMaterials were deep-copied by the
+            // old bundled config (it registered Diet/DefaultManureCompositionData/Table_30 alongside Farm). ReplicateFarm
+            // now reproduces those deep copies with explicit clone loops, so this mapper only needs the Farm map itself.
+            _farmMapper = new ModelMapper<Farm>(
+                nameof(Farm.Name), nameof(Farm.Guid), nameof(Farm.Defaults), nameof(Farm.StageStates),
+                nameof(Farm.ClimateData), nameof(Farm.GeographicData), nameof(Farm.Components));
 
-                x.CreateMap<Table_15_Default_Soil_N2O_Emission_BreakDown_Provider,
-                    Table_15_Default_Soil_N2O_Emission_BreakDown_Provider>();
-                x.CreateMap<Table_30_Default_Bedding_Material_Composition_Data,
-                    Table_30_Default_Bedding_Material_Composition_Data>();
-                x.CreateMap<DefaultManureCompositionData, DefaultManureCompositionData>();
+            _defaultsMapper = new ModelMapper<Defaults>();
 
-                x.CreateMap<Diet, Diet>();
-            });
+            _detailsScreenCropViewItemMapper = new ModelMapper<CropViewItem>();
 
-            _farmMapper = farmMapperConfiguration.CreateMapper();
+            // ClimateData's Precipitation/Temperature/Evapotranspiration/BarnTemperature were deep-copied by the old
+            // bundled config; ReplicateFarm reproduces those with explicit clones after this map runs.
+            _climateDataMapper = new ModelMapper<ClimateData>(
+                nameof(ClimateData.DailyClimateData), nameof(ClimateData.Guid));
 
-            #endregion
+            _dailyClimateDataMapper = new ModelMapper<DailyClimateData>();
 
-            #region Defaults
+            _geographicDataMapper = new ModelMapper<GeographicData>(
+                nameof(GeographicData.SoilDataForAllComponentsWithinPolygon),
+                nameof(GeographicData.DefaultSoilData),
+                nameof(GeographicData.CustomYieldData),
+                nameof(GeographicData.Guid));
 
-            var defaultMapperConfiguration = new MapperConfiguration(x => { x.CreateMap<Defaults, Defaults>(); });
+            _soilDataMapper = new ModelMapper<SoilData>();
 
-            _defaultsMapper = defaultMapperConfiguration.CreateMapper();
-
-            #endregion
-
-            #region Details Screen
-
-            var detailsScreenCropViewItemMapperConfiguration = new MapperConfiguration(x =>
-                {
-                    x.CreateMap<CropViewItem, CropViewItem>();
-                });
-
-            _detailsScreenCropViewItemMapper = detailsScreenCropViewItemMapperConfiguration.CreateMapper();
-
-            #endregion
-
-            #region Climate Mappers
-
-            var climateDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<PrecipitationData, PrecipitationData>();
-                x.CreateMap<TemperatureData, TemperatureData>();
-                x.CreateMap<EvapotranspirationData, EvapotranspirationData>();
-                x.CreateMap<ClimateData, ClimateData>()
-                    .ForMember(y => y.DailyClimateData, z => z.Ignore())
-                    .ForMember(y => y.Guid, z => z.Ignore());
-            });
-
-            _climateDataMapper = climateDataMapper.CreateMapper();
-
-            var dailyclimateDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<DailyClimateData, DailyClimateData>();
-            });
-
-            _dailyClimateDataMapper = dailyclimateDataMapper.CreateMapper();
-
-            #endregion
-
-            #region GeographicData Mappers
-
-            var geographicDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<GeographicData, GeographicData>()
-                    .ForMember(y => y.SoilDataForAllComponentsWithinPolygon, z => z.Ignore())
-                    .ForMember(y => y.DefaultSoilData, z => z.Ignore())
-                    .ForMember(y => y.CustomYieldData, z => z.Ignore())
-                    .ForMember(y => y.Guid, z => z.Ignore());
-            });
-
-            _geographicDataMapper = geographicDataMapper.CreateMapper();
-
-            var soilDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<SoilData, SoilData>();
-            });
-
-            _soilDataMapper = soilDataMapper.CreateMapper();
-
-            var customYieldMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<CustomUserYieldData, CustomUserYieldData>();
-            });
-
-            _customYieldDataMapper = customYieldMapper.CreateMapper();
+            _customYieldDataMapper = new ModelMapper<CustomUserYieldData>();
 
             #endregion
         }
@@ -366,6 +300,32 @@ namespace H.Core.Services
             _geographicDataMapper.Map(farm.GeographicData, replicatedFarm.GeographicData);
 
             replicatedFarm.Name = farm.Name;
+
+            // Reproduce the deep copies the previous bundled AutoMapper configurations performed. The Farm and
+            // ClimateData maps above are shallow, so without these explicit clones the replicated farm would share these
+            // references (and their list elements) with the original farm.
+            replicatedFarm.ClimateData.PrecipitationData = PropertyMapper.Clone(farm.ClimateData.PrecipitationData);
+            replicatedFarm.ClimateData.TemperatureData = PropertyMapper.Clone(farm.ClimateData.TemperatureData);
+            replicatedFarm.ClimateData.EvapotranspirationData = PropertyMapper.Clone(farm.ClimateData.EvapotranspirationData);
+            replicatedFarm.ClimateData.BarnTemperatureData = PropertyMapper.Clone(farm.ClimateData.BarnTemperatureData);
+
+            replicatedFarm.Diets.Clear();
+            foreach (var diet in farm.Diets)
+            {
+                replicatedFarm.Diets.Add(PropertyMapper.Clone(diet));
+            }
+
+            replicatedFarm.DefaultManureCompositionData.Clear();
+            foreach (var defaultManureCompositionData in farm.DefaultManureCompositionData)
+            {
+                replicatedFarm.DefaultManureCompositionData.Add(PropertyMapper.Clone(defaultManureCompositionData));
+            }
+
+            replicatedFarm.DefaultsCompositionOfBeddingMaterials.Clear();
+            foreach (var beddingMaterialComposition in farm.DefaultsCompositionOfBeddingMaterials)
+            {
+                replicatedFarm.DefaultsCompositionOfBeddingMaterials.Add(PropertyMapper.Clone(beddingMaterialComposition));
+            }
 
             #region Animal Components
 

--- a/H.Core/Services/FieldComponentHelper.cs
+++ b/H.Core/Services/FieldComponentHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.LandManagement.Fields;
@@ -17,15 +17,15 @@ namespace H.Core.Services
     {
         #region Fields
 
-        private readonly IMapper _cropViewItemMapper;
-        private readonly IMapper _cropEconomicDataMapper;
-        private readonly IMapper _grazingPeriodMapper;
-        private readonly IMapper _harvestPeriodMapper;
-        private readonly IMapper _manureApplicationViewItemMapper;
-        private readonly IMapper _fertilizerApplicationViewItemMapper;
-        private readonly IMapper _hayImportViewItemMapper;
-        private readonly IMapper _digestateViewItemMapper;
-        private readonly IMapper _soilDataMapper;
+        private readonly ModelMapper<CropViewItem> _cropViewItemMapper;
+        private readonly ModelMapper<CropEconomicData> _cropEconomicDataMapper;
+        private readonly ModelMapper<GrazingViewItem> _grazingPeriodMapper;
+        private readonly ModelMapper<HarvestViewItem> _harvestPeriodMapper;
+        private readonly ModelMapper<ManureApplicationViewItem> _manureApplicationViewItemMapper;
+        private readonly ModelMapper<FertilizerApplicationViewItem> _fertilizerApplicationViewItemMapper;
+        private readonly ModelMapper<HayImportViewItem> _hayImportViewItemMapper;
+        private readonly ModelMapper<DigestateApplicationViewItem> _digestateViewItemMapper;
+        private readonly ModelMapper<SoilData> _soilDataMapper;
 
         ICropInitializationService _cropInitializationService;
 
@@ -37,76 +37,31 @@ namespace H.Core.Services
         {
             _cropInitializationService = new CropInitializationService();
 
-            var cropViewItemMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<CropViewItem, CropViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore())
-                    .ForMember(y => y.HarvestViewItems, z => z.Ignore())
-                    .ForMember(y => y.GrazingViewItems, z => z.Ignore())
-                    .ForMember(y => y.ManureApplicationViewItems, z => z.Ignore())
-                    .ForMember(y => y.CropEconomicData, z => z.Ignore())
-                    .ForMember(y => y.FertilizerApplicationViewItems, z => z.Ignore());
-            });
+            _cropViewItemMapper = new ModelMapper<CropViewItem>(
+                nameof(CropViewItem.Guid),
+                nameof(CropViewItem.HarvestViewItems),
+                nameof(CropViewItem.GrazingViewItems),
+                nameof(CropViewItem.ManureApplicationViewItems),
+                nameof(CropViewItem.CropEconomicData),
+                nameof(CropViewItem.FertilizerApplicationViewItems));
 
-            _cropViewItemMapper = cropViewItemMapperConfiguration.CreateMapper();
+            _cropEconomicDataMapper = new ModelMapper<CropEconomicData>();
 
-            var cropEconomicDataMapperConfiguration =
-                new MapperConfiguration(x => x.CreateMap<CropEconomicData, CropEconomicData>());
+            _harvestPeriodMapper = new ModelMapper<HarvestViewItem>(nameof(HarvestViewItem.Guid));
 
-            _cropEconomicDataMapper = cropEconomicDataMapperConfiguration.CreateMapper();
+            _grazingPeriodMapper = new ModelMapper<GrazingViewItem>(nameof(GrazingViewItem.Guid));
 
-            var harvestPeriodMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<HarvestViewItem, HarvestViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore());
-            });
+            _manureApplicationViewItemMapper = new ModelMapper<ManureApplicationViewItem>();
 
-            _harvestPeriodMapper = harvestPeriodMapperConfiguration.CreateMapper();
+            _hayImportViewItemMapper = new ModelMapper<HayImportViewItem>();
 
-            var grazingPeriodMapperConfiguration = new MapperConfiguration(x =>
-            {
-                x.CreateMap<GrazingViewItem, GrazingViewItem>()
-                    .ForMember(y => y.Guid, z => z.Ignore());
-            });
+            _digestateViewItemMapper = new ModelMapper<DigestateApplicationViewItem>();
 
-            _grazingPeriodMapper = grazingPeriodMapperConfiguration.CreateMapper();
+            // The fertilizer item map was bundled with Table_48 so FertilizerBlendData was deep-copied; Replicate()
+            // now reproduces that with an explicit clone (the shallow mapper alone would share the blend reference).
+            _fertilizerApplicationViewItemMapper = new ModelMapper<FertilizerApplicationViewItem>();
 
-            var manureApplicationViewItemMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<ManureApplicationViewItem, ManureApplicationViewItem>();
-            });
-
-            _manureApplicationViewItemMapper = manureApplicationViewItemMapper.CreateMapper();
-
-            var hayImportViewItemMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<HayImportViewItem, HayImportViewItem>();
-            });
-
-            _hayImportViewItemMapper = hayImportViewItemMapper.CreateMapper();
-
-            var digestateViewItemMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<DigestateApplicationViewItem, DigestateApplicationViewItem>();
-            });
-
-            _digestateViewItemMapper = digestateViewItemMapper.CreateMapper();
-
-
-            var fertilizerApplicationViewItemMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data, Table_48_Carbon_Footprint_For_Fertilizer_Blends_Data>();
-                x.CreateMap<FertilizerApplicationViewItem, FertilizerApplicationViewItem>();
-            });
-            
-            _fertilizerApplicationViewItemMapper = fertilizerApplicationViewItemMapper.CreateMapper();
-
-            var soilDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<SoilData, SoilData>();
-            });
-
-            _soilDataMapper = soilDataMapper.CreateMapper();
+            _soilDataMapper = new ModelMapper<SoilData>();
         }
 
         #endregion
@@ -218,6 +173,11 @@ namespace H.Core.Services
                     var copiedFertilizerApplicationViewItem = new FertilizerApplicationViewItem();
 
                     _fertilizerApplicationViewItemMapper.Map(fertilizerApplicationViewItem, copiedFertilizerApplicationViewItem);
+
+                    // Reproduce the deep-copy the previous bundled mapper performed for the blend data.
+                    copiedFertilizerApplicationViewItem.FertilizerBlendData =
+                        PropertyMapper.Clone(fertilizerApplicationViewItem.FertilizerBlendData);
+
                     copiedViewItem.FertilizerApplicationViewItems.Add(copiedFertilizerApplicationViewItem);
                 }
             }

--- a/H.Core/Services/Initialization/Animals/AnimalInitializationService.Bedding.cs
+++ b/H.Core/Services/Initialization/Animals/AnimalInitializationService.Bedding.cs
@@ -117,7 +117,7 @@ namespace H.Core.Services.Initialization.Animals
 
             foreach (var item in source)
             {
-                var copiedInstance = _defaultBeddingCompositionDataMapper.Map<Table_30_Default_Bedding_Material_Composition_Data, Table_30_Default_Bedding_Material_Composition_Data>(item);
+                var copiedInstance = _defaultBeddingCompositionDataMapper.Map(item);
                 beddingMaterialCompositionData.Add(copiedInstance);
             }
             return beddingMaterialCompositionData;

--- a/H.Core/Services/Initialization/Animals/AnimalInitializationService.ManureComposition.cs
+++ b/H.Core/Services/Initialization/Animals/AnimalInitializationService.ManureComposition.cs
@@ -71,7 +71,7 @@ namespace H.Core.Services.Initialization.Animals
 
             foreach (var item in source)
             {
-                var copiedInstance = _defaultManureCompositionDataMapper.Map<DefaultManureCompositionData, DefaultManureCompositionData>(item);
+                var copiedInstance = _defaultManureCompositionDataMapper.Map(item);
                 manureCompositionData.Add(copiedInstance);
             }
             return manureCompositionData;

--- a/H.Core/Services/Initialization/Animals/AnimalInitializationService.cs
+++ b/H.Core/Services/Initialization/Animals/AnimalInitializationService.cs
@@ -3,7 +3,7 @@ using H.Core.Providers.Climate;
 using System.Collections.Generic;
 using H.Core.Calculators.Nitrogen;
 using H.Core.Models;
-using AutoMapper;
+using H.Core.Mappers;
 
 namespace H.Core.Services.Initialization.Animals
 {
@@ -34,8 +34,8 @@ namespace H.Core.Services.Initialization.Animals
         private readonly Table_42_Poultry_OtherLivestock_Default_NExcretionRates_Provider _poultryOtherLivestockDefaultNExcretionRatesProvider;
 
         private static readonly Table_22_Livestock_Coefficients_Sheep_Provider _sheepProvider;
-        private IMapper _defaultManureCompositionDataMapper;
-        private IMapper _defaultBeddingCompositionDataMapper;
+        private ModelMapper<DefaultManureCompositionData> _defaultManureCompositionDataMapper;
+        private ModelMapper<Table_30_Default_Bedding_Material_Composition_Data> _defaultBeddingCompositionDataMapper;
 
         #endregion
 
@@ -110,19 +110,8 @@ namespace H.Core.Services.Initialization.Animals
 
         private void InitializeMappers()
         {
-            var _manureCompositionDataMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<DefaultManureCompositionData, DefaultManureCompositionData>();
-            });
-
-            _defaultManureCompositionDataMapper = _manureCompositionDataMapperConfiguration.CreateMapper();
-
-            var _beddingMaterialCompositionMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<Table_30_Default_Bedding_Material_Composition_Data, Table_30_Default_Bedding_Material_Composition_Data>();
-            });
-
-            _defaultBeddingCompositionDataMapper = _beddingMaterialCompositionMapperConfiguration.CreateMapper();
+            _defaultManureCompositionDataMapper = new ModelMapper<DefaultManureCompositionData>();
+            _defaultBeddingCompositionDataMapper = new ModelMapper<Table_30_Default_Bedding_Material_Composition_Data>();
         }
 
         #endregion

--- a/H.Core/Services/Initialization/Crops/CropInitializationService.Custom.cs
+++ b/H.Core/Services/Initialization/Crops/CropInitializationService.Custom.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Models.LandManagement.Fields;
 using H.Core.Models;
 
@@ -26,17 +26,12 @@ namespace H.Core.Services.Initialization.Crops
                 return;
             }
 
-            var customCropDefaultsMapperConfiguration = new MapperConfiguration(configuration =>
-            {
-                // Don't copy the GUID, and do not overwrite the year, name, or area, on the crop
-                configuration.CreateMap<CropViewItem, CropViewItem>()
-                    .ForMember(x => x.Guid, options => options.Ignore())
-                    .ForMember(x => x.Year, options => options.Ignore())
-                    .ForMember(x => x.Name, options => options.Ignore())
-                    .ForMember(x => x.Area, options => options.Ignore());
-            });
-
-            var mapper = customCropDefaultsMapperConfiguration.CreateMapper();
+            // Don't copy the GUID, and do not overwrite the year, name, or area, on the crop
+            var mapper = new ModelMapper<CropViewItem>(
+                nameof(CropViewItem.Guid),
+                nameof(CropViewItem.Year),
+                nameof(CropViewItem.Name),
+                nameof(CropViewItem.Area));
 
             mapper.Map(cropDefaults, viewItem);
         }

--- a/H.Core/Services/Initialization/Crops/CropInitializationService.cs
+++ b/H.Core/Services/Initialization/Crops/CropInitializationService.cs
@@ -19,8 +19,7 @@ using H.Core.Providers.Fertilizer;
 using H.Core.Providers.Nitrogen;
 using H.Core.Providers.Energy;
 using H.Core.Services.LandManagement;
-using AutoMapper;
-using AutoMapper.Configuration.Annotations;
+using H.Core.Mappers;
 using H.Core.Services.Animals;
 
 namespace H.Core.Services.Initialization.Crops
@@ -50,7 +49,7 @@ namespace H.Core.Services.Initialization.Crops
         private static readonly Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider _carbonFootprintForFertilizerBlendsProvider;
         private static readonly Table_50_Fuel_Energy_Estimates_Provider _fuelEnergyEstimatesProvider;
 
-        private readonly IMapper _soilDataMapper;
+        private readonly ModelMapper<SoilData> _soilDataMapper;
 
         #endregion
 
@@ -83,12 +82,7 @@ namespace H.Core.Services.Initialization.Crops
             _utilizationRatesForLivestockGrazingProvider = new Table_60_Utilization_Rates_For_Livestock_Grazing_Provider();
             _manureService = new ManureService();
 
-            var soilDataMapper = new MapperConfiguration(x =>
-            {
-                x.CreateMap<SoilData, SoilData>();
-            });
-
-            _soilDataMapper = soilDataMapper.CreateMapper();
+            _soilDataMapper = new ModelMapper<SoilData>();
         }
 
         #endregion

--- a/H.Core/Services/Initialization/InitializationService.cs
+++ b/H.Core/Services/Initialization/InitializationService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
-using AutoMapper;
 using H.Core.Calculators.Carbon;
 using H.Core.Calculators.Economics;
 using H.Core.Calculators.Nitrogen;

--- a/H.Core/Services/LandManagement/FieldResultsService.Carbon.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.Carbon.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Eventing.Reader;
 using System.Linq;
-using AutoMapper.Configuration.Annotations;
 using H.Core.Emissions.Results;
 using H.Core.Enumerations;
 using H.Core.Models;

--- a/H.Core/Services/LandManagement/FieldResultsService.DetailViewItems.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.DetailViewItems.cs
@@ -27,12 +27,12 @@ namespace H.Core.Services.LandManagement
         /// <returns>A duplicated <see cref="H.Core.Models.LandManagement.Fields.CropViewItem"/></returns>
         public CropViewItem MapDetailsScreenViewItemFromComponentScreenViewItem(CropViewItem viewItem, int year)
         {
-            var result = _detailViewItemMapper.Map<CropViewItem, CropViewItem>(viewItem);
+            var result = _detailViewItemMapper.Map(viewItem);
 
             // Copy all manure applications to the detail view item
             foreach (var manureApplicationViewItem in viewItem.ManureApplicationViewItems)
             {
-                var copiedManureApplicationViewItem = _manureApplicationViewItemMapper.Map<ManureApplicationViewItem, ManureApplicationViewItem>(manureApplicationViewItem);
+                var copiedManureApplicationViewItem = _manureApplicationViewItemMapper.Map(manureApplicationViewItem);
 
                 // We need to update the year so that the current years' manure applications are copied back in time
                 copiedManureApplicationViewItem.DateOfApplication = new DateTime(year, manureApplicationViewItem.DateOfApplication.Month, manureApplicationViewItem.DateOfApplication.Day);
@@ -42,7 +42,7 @@ namespace H.Core.Services.LandManagement
 
             foreach (var harvestViewItem in viewItem.HarvestViewItems)
             {
-                var copiedHarvestViewItem = _harvestViewItemMapper.Map<HarvestViewItem, HarvestViewItem>(harvestViewItem);
+                var copiedHarvestViewItem = _harvestViewItemMapper.Map(harvestViewItem);
 
                 // We need to update the year so that the current years' harvest items are copied back in time
                 copiedHarvestViewItem.DateCreated = new DateTime(year, harvestViewItem.DateCreated.Month, harvestViewItem.DateCreated.Day);
@@ -52,7 +52,7 @@ namespace H.Core.Services.LandManagement
 
             foreach (var grazingViewItem in viewItem.GrazingViewItems)
             {
-                var copiedGrazingViewItem = _harvestViewItemMapper.Map<GrazingViewItem, GrazingViewItem>(grazingViewItem);
+                var copiedGrazingViewItem = _grazingViewItemMapper.Map(grazingViewItem);
 
                 // We need to update the year so that the current years' harvest items are copied back in time
                 copiedGrazingViewItem.DateCreated = new DateTime(year, grazingViewItem.DateCreated.Month, grazingViewItem.DateCreated.Day);
@@ -62,7 +62,7 @@ namespace H.Core.Services.LandManagement
 
             foreach (var hayImportViewItem in viewItem.HayImportViewItems)
             {
-                var copiedHayImportViewItem = _hayImportViewItemMapper.Map<HayImportViewItem, HayImportViewItem>(hayImportViewItem);
+                var copiedHayImportViewItem = _hayImportViewItemMapper.Map(hayImportViewItem);
 
                 // We need to update the year so that the current years' hay import items are copied back in time
                 copiedHayImportViewItem.Date = new DateTime(year, copiedHayImportViewItem.DateCreated.Month, copiedHayImportViewItem.DateCreated.Day);
@@ -72,7 +72,7 @@ namespace H.Core.Services.LandManagement
 
             foreach (var fertilizerApplicationViewItem in viewItem.FertilizerApplicationViewItems)
             {
-                var copiedFertilizerViewItem = _fertilizerViewItemMapper.Map<FertilizerApplicationViewItem, FertilizerApplicationViewItem>(fertilizerApplicationViewItem);
+                var copiedFertilizerViewItem = _fertilizerViewItemMapper.Map(fertilizerApplicationViewItem);
 
                 // We need to update the year so that the current years' fertilizer applications are copied back in time
                 copiedFertilizerViewItem.DateCreated = new DateTime(year, fertilizerApplicationViewItem.DateCreated.Month, fertilizerApplicationViewItem.DateCreated.Day);
@@ -82,7 +82,7 @@ namespace H.Core.Services.LandManagement
 
             foreach (var digestateApplicationViewItem in viewItem.DigestateApplicationViewItems)
             {
-                var copiedDigestateViewItem = _digestateViewItemMapper.Map<DigestateApplicationViewItem, DigestateApplicationViewItem>(digestateApplicationViewItem);
+                var copiedDigestateViewItem = _digestateViewItemMapper.Map(digestateApplicationViewItem);
 
                 // We need to update the year so that the current years' digestate applications are copied back in time
                 copiedDigestateViewItem.DateCreated = new DateTime(year, digestateApplicationViewItem.DateCreated.Month, digestateApplicationViewItem.DateCreated.Day);

--- a/H.Core/Services/LandManagement/FieldResultsService.Initialization.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.Initialization.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using AutoMapper;
 using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.LandManagement.Fields;

--- a/H.Core/Services/LandManagement/FieldResultsService.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Media;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Calculators.Carbon;
 using H.Core.Calculators.Climate;
 using H.Core.Calculators.Economics;
@@ -51,13 +51,13 @@ namespace H.Core.Services.LandManagement
         private readonly N2OEmissionFactorCalculator _n2OEmissionFactorCalculator;
         private readonly IManureService _manureService = new ManureService();
 
-        private readonly IMapper _detailViewItemMapper;
-        private readonly IMapper _manureApplicationViewItemMapper;
-        private readonly IMapper _harvestViewItemMapper;
-        private readonly IMapper _hayImportViewItemMapper;
-        private readonly IMapper _fertilizerViewItemMapper;
-        private readonly IMapper _digestateViewItemMapper;
-        private readonly IMapper _grazingViewItemMapper;
+        private readonly ModelMapper<CropViewItem> _detailViewItemMapper;
+        private readonly ModelMapper<ManureApplicationViewItem> _manureApplicationViewItemMapper;
+        private readonly ModelMapper<HarvestViewItem> _harvestViewItemMapper;
+        private readonly ModelMapper<GrazingViewItem> _grazingViewItemMapper;
+        private readonly ModelMapper<HayImportViewItem> _hayImportViewItemMapper;
+        private readonly ModelMapper<FertilizerApplicationViewItem> _fertilizerViewItemMapper;
+        private readonly ModelMapper<DigestateApplicationViewItem> _digestateViewItemMapper;
 
         private readonly Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider _carbonFootprintForFertilizerBlendsProvider = new Table_48_Carbon_Footprint_For_Fertilizer_Blends_Provider();
 
@@ -124,70 +124,37 @@ namespace H.Core.Services.LandManagement
              * Create a mapper that will map component selection view items to detail view items
              */
 
-            var componentSelectionViewItemToDetailViewItemMapperConfiguration = new MapperConfiguration(configuration =>
-            {
-                configuration.CreateMap<CropViewItem, CropViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore())
-                    .ForMember(property => property.HarvestViewItems, options => options.Ignore())
-                    .ForMember(property => property.GrazingViewItems, options => options.Ignore())
-                    .ForMember(property => property.FertilizerApplicationViewItems, options => options.Ignore())
-                    .ForMember(property => property.HayImportViewItems, options => options.Ignore())
-                    .ForMember(property => property.DigestateApplicationViewItems, options => options.Ignore())
-                    .ForMember(property => property.ManureApplicationViewItems, options => options.Ignore())
-                    .ForMember(property => property.MonthlyIpccTier2TemperatureFactors, options => options.Ignore())
-                    .ForMember(property => property.MonthlyIpccTier2WaterFactors, options => options.Ignore());
-            });
+            _detailViewItemMapper = new ModelMapper<CropViewItem>(
+                nameof(CropViewItem.Name),
+                nameof(CropViewItem.Guid),
+                nameof(CropViewItem.HarvestViewItems),
+                nameof(CropViewItem.GrazingViewItems),
+                nameof(CropViewItem.FertilizerApplicationViewItems),
+                nameof(CropViewItem.HayImportViewItems),
+                nameof(CropViewItem.DigestateApplicationViewItems),
+                nameof(CropViewItem.ManureApplicationViewItems),
+                nameof(CropViewItem.MonthlyIpccTier2TemperatureFactors),
+                nameof(CropViewItem.MonthlyIpccTier2WaterFactors));
 
-            _detailViewItemMapper = componentSelectionViewItemToDetailViewItemMapperConfiguration.CreateMapper();
+            _manureApplicationViewItemMapper = new ModelMapper<ManureApplicationViewItem>(
+                nameof(ManureApplicationViewItem.Name), nameof(ManureApplicationViewItem.Guid));
 
-            var manureApplicationViewItemConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<ManureApplicationViewItem, ManureApplicationViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
+            _hayImportViewItemMapper = new ModelMapper<HayImportViewItem>(
+                nameof(HayImportViewItem.Name), nameof(HayImportViewItem.Guid));
 
-            var hayImportViewItemMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<HayImportViewItem, HayImportViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
+            // Grazing items were previously (incorrectly) cloned via the harvest mapper - a latent bug that only compiled
+            // because AutoMapper's IMapper.Map<TSource,TDest> is untyped. Wire the intended grazing mapper.
+            _grazingViewItemMapper = new ModelMapper<GrazingViewItem>(
+                nameof(GrazingViewItem.Name), nameof(GrazingViewItem.Guid));
 
-            var grazingViewItemMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<GrazingViewItem, GrazingViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
+            _harvestViewItemMapper = new ModelMapper<HarvestViewItem>(
+                nameof(HarvestViewItem.Name), nameof(HarvestViewItem.Guid));
 
-            var harvestViewItemMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<HarvestViewItem, HarvestViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
+            _fertilizerViewItemMapper = new ModelMapper<FertilizerApplicationViewItem>(
+                nameof(FertilizerApplicationViewItem.Name), nameof(FertilizerApplicationViewItem.Guid));
 
-            var fertilizerViewItemMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<FertilizerApplicationViewItem, FertilizerApplicationViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
-
-            var digestateViewItemMapperConfiguration = new MapperConfiguration(configure: configuration =>
-            {
-                configuration.CreateMap<DigestateApplicationViewItem, DigestateApplicationViewItem>()
-                    .ForMember(property => property.Name, options => options.Ignore())
-                    .ForMember(property => property.Guid, options => options.Ignore());
-            });
-
-            _manureApplicationViewItemMapper = manureApplicationViewItemConfiguration.CreateMapper();
-            _hayImportViewItemMapper = hayImportViewItemMapperConfiguration.CreateMapper();
-            _harvestViewItemMapper = harvestViewItemMapperConfiguration.CreateMapper();
-            _fertilizerViewItemMapper = fertilizerViewItemMapperConfiguration.CreateMapper();
-            _digestateViewItemMapper = digestateViewItemMapperConfiguration.CreateMapper();
+            _digestateViewItemMapper = new ModelMapper<DigestateApplicationViewItem>(
+                nameof(DigestateApplicationViewItem.Name), nameof(DigestateApplicationViewItem.Guid));
 
             _smallAreaYieldProvider.Initialize();
 

--- a/H.Core/Services/RotationComponentHelper.cs
+++ b/H.Core/Services/RotationComponentHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using AutoMapper;
+using H.Core.Mappers;
 using H.Core.Enumerations;
 using H.Core.Models;
 using H.Core.Models.LandManagement.Fields;
@@ -15,7 +15,7 @@ namespace H.Core.Services
     {
         #region Fields
         
-        private readonly IMapper _cropViewItemMapper;
+        private readonly ModelMapper<CropViewItem> _cropViewItemMapper;
         private readonly FieldComponentHelper _fieldComponentHelper;
 
         #endregion
@@ -28,14 +28,8 @@ namespace H.Core.Services
 
             _fieldComponentHelper = new FieldComponentHelper();
 
-            var cropViewItemMappingConfiguration = new MapperConfiguration(configuration =>
-            {
-                configuration.CreateMap<CropViewItem, CropViewItem>()
-                    .ForMember(x => x.IsInitialized, options => options.Ignore())
-                    .ForMember(x => x.Guid, options => options.Ignore());
-            });
-
-            _cropViewItemMapper = cropViewItemMappingConfiguration.CreateMapper();
+            _cropViewItemMapper = new ModelMapper<CropViewItem>(
+                nameof(CropViewItem.IsInitialized), nameof(CropViewItem.Guid));
         }
 
         #endregion


### PR DESCRIPTION
## Why

Dependabot flags **AutoMapper 9.0.0** for **CVE-2026-32933** (uncontrolled recursion / DoS). It can't be upgraded in place: the fix ships only in AutoMapper 15.1.3 / 16.1.1+, which require .NET 8/9, and the Telerik UI dependency keeps this solution on **net48**. So the only path is to remove AutoMapper.

## What

AutoMapper was only ever used here for same-type `CreateMap<T, T>()` clone/copy operations, so it's replaced with a small hand-rolled convention mapper:

- **`H.Core/Mappers/PropertyMapper.cs`** — a non-recursive property copier (immune to the CVE). Copies scalars/enums by value, shares complex references, and rebuilds collections as a new container with the same element references — matching AutoMapper's observed behaviour for these maps.
- **`H.Core/Mappers/ModelMapper<T>`** — thin adapter exposing `Map(source)` / `Map(source, destination)`.
- All `H.Core` call sites migrated off `IMapper` / `MapperConfiguration`.
- **`AutoMapper` `PackageReference` removed** from `H.Core.csproj` (the actual CVE remediation).

## Tests

- `H.Core.Test/Mappers/AutoMapperCharacterizationTest.cs` locks the copy contract (scalars/enums copied, complex refs shared, collections rebuilt with shared elements, polymorphic-source regression).
- Full `H.Core.Test`: **1144 passed, 0 failed, 13 skipped** (identical to the pre-change baseline).
- Full public solution builds clean.

_Note: the corresponding view-model call-site changes live in the private GUI repo (Telerik view code is not part of this public repository)._