### PR TITLE
Publish to nuget.org via Trusted Publishing (OIDC), not an API key

### DIFF
--- a/.github/workflows/_dotnet-nuget-template.yml
+++ b/.github/workflows/_dotnet-nuget-template.yml
@@ -9,8 +9,10 @@ on:
 jobs:
   reusable_workflow_job:
     runs-on:  windows-latest
-    env:
-        NUGET_AUTH_TOKEN: ${{ secrets.HOLOS_NUGET_KEY }}
+    permissions:
+      id-token: write   # request the OIDC token for nuget.org Trusted Publishing
+      contents: read
+      packages: write   # push to GitHub Packages (uses GITHUB_TOKEN)
     steps:
     
     - name: Get date/time
@@ -42,8 +44,14 @@ jobs:
     - name: Add registry
       run: dotnet nuget add source --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
     
+    - name: NuGet login (Trusted Publishing - exchange OIDC token for a short-lived key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: holos-aafc
+
     - name: Publish packages to nuget.org
-      run: dotnet nuget push "*/**/aafc*.nupkg" -k $env:NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*/**/aafc*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Publish packages to github
       run: dotnet nuget push "*/**/aafc*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"

--- a/.github/workflows/dotnet-build-publish.yml
+++ b/.github/workflows/dotnet-build-publish.yml
@@ -15,6 +15,10 @@ jobs:
 
   nuget:
     needs: build
+    permissions:
+      id-token: write   # allow the reusable workflow to mint the OIDC token for Trusted Publishing
+      contents: read
+      packages: write
     uses: ./.github/workflows/_dotnet-nuget-template.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Why
The **Build and publish new release** workflow has failed since ~June 2026 with a **403** on the nuget.org push — the long-lived API key in the `HOLOS_NUGET_KEY` secret expired (last successful publish: `4.0.20260410.1708`). Minting a new key would just expire again.

This switches to **nuget.org Trusted Publishing**: GitHub issues a short-lived OIDC token per run, nuget.org exchanges it for a 1-hour key. No secret to store, rotate, or expire.

## Changes
- `_dotnet-nuget-template.yml`: add `permissions: id-token: write` (+ `contents: read`, `packages: write`); add a `NuGet/login@v1` step right before the push; push with `${{ steps.login.outputs.NUGET_API_KEY }}`; remove the `HOLOS_NUGET_KEY` env/secret.
- `dotnet-build-publish.yml`: grant the same permissions on the `nuget:` calling job so the reusable workflow can mint the OIDC token.
- GitHub Packages push unchanged (`GITHUB_TOKEN`).

## Requires (already done)
Trusted Publishing policy on nuget.org — owner `holos-aafc`, repo `holos-aafc/Holos`, workflow file `dotnet-build-publish.yml`.

## Notes
- Publish runs in a reusable workflow; the policy names the entry workflow (`dotnet-build-publish.yml`). If the token exchange is rejected, switch the policy's workflow file to `_dotnet-nuget-template.yml`.
- After a successful publish, the `HOLOS_NUGET_KEY` secret is unused and can be deleted.