### PR TITLE
CI: bump actions to Node 24, replace unmaintained Setup-VSTest

### DIFF
--- a/.github/workflows/_dotnet-build-template.yml
+++ b/.github/workflows/_dotnet-build-template.yml
@@ -17,15 +17,27 @@ jobs:
       Solution_Name: Holos.sln
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
-        fetch-depth: 0        
+        fetch-depth: 0
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
+    # darenm/Setup-VSTest is unmaintained and still runs on Node 20. The runner's
+    # Visual Studio install already ships vstest.console.exe, so locate it with
+    # vswhere and put it on PATH instead.
     - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vstest = & $vswhere -latest -products * -find "**\TestPlatform\vstest.console.exe" | Select-Object -First 1
+        if (-not $vstest) {
+          $vstest = & $vswhere -latest -products * -find "**\vstest.console.exe" | Select-Object -First 1
+        }
+        if (-not $vstest) { throw "vstest.console.exe not found on the runner" }
+        Write-Host "Using vstest.console.exe: $vstest"
+        Split-Path -Parent $vstest | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
     - name: Restore nuget packages
       run: msbuild ${{ inputs.solution }} /t:Restore /m
@@ -42,7 +54,7 @@ jobs:
 
     - name: Upload build artifacts
       if: ${{ inputs.configuration == 'Release' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.filename }}
         path: '**/H.Core/bin/*'

--- a/.github/workflows/_dotnet-nuget-template.yml
+++ b/.github/workflows/_dotnet-nuget-template.yml
@@ -17,17 +17,17 @@ jobs:
     
     - name: Get date/time
       id: t1
-      uses: Kaven-Universe/github-action-current-date-time@v1.4.0
+      uses: Kaven-Universe/github-action-current-date-time@v1.5.0
       with:
         format: "YYYYMMDD.HHmm"
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Restore nuget packages
       run: msbuild H.Core/H.Core.csproj /t:Restore /m
@@ -57,7 +57,7 @@ jobs:
       run: dotnet nuget push "*/**/aafc*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Holos4-nuget-pkg
         path: '*/**/aafc*.nupkg'

--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
 
     - name: "Download build"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.filename }}
 
-    - uses: vimtor/action-zip@v1.2
+    - uses: vimtor/action-zip@v1.3
       with:
         files: H.Core/
         dest: ${{ inputs.filename }}.zip


### PR DESCRIPTION
## Why
Every run is annotated with **"Node.js 20 is deprecated … being forced to run on Node.js 24"**. These still work today, but will break when GitHub drops Node 20.

## What
I checked each action's `action.yml` (`runs.using`) rather than assuming, because **the obvious bump isn't always enough** — e.g. `upload-artifact@v5` and `download-artifact@v5/v6` are *still* node20.

| Action | From | To | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | first node24 |
| `microsoft/setup-msbuild` | v2 | **v3** | |
| `actions/upload-artifact` | v4 | **v6** | v5 still node20 |
| `actions/download-artifact` | v4 | **v7** | v5/v6 still node20 |
| `vimtor/action-zip` | v1.2 | **v1.3** | |
| `Kaven-Universe/…current-date-time` | v1.4.0 | **v1.5.0** | |

### `darenm/Setup-VSTest` — replaced, not bumped
It's **node20 even at its latest tag** and unmaintained since 2024, so no bump fixes it. The runner's Visual Studio install already ships `vstest.console.exe`, so it's now located with `vswhere` and added to `PATH`. One less dead third-party dependency.

## Validation
The `[PR] Build and Test` check runs `_dotnet-build-template.yml`, so it exercises `checkout@v5`, `setup-msbuild@v3`, **the new VSTest lookup, and the actual test run** — i.e. the riskiest change is verified by this PR before merge.

## Follow-up (not in this PR)
`actions/create-release` and `actions/upload-release-asset` are **node12 and ARCHIVED**; `eregon/publish-release` is **node20 and ARCHIVED**. Bumping can't fix these — they need replacing (e.g. with `softprops/action-gh-release`), which changes release behaviour and only runs on `main`, so it deserves its own PR.