### PR TITLE
CI: replace archived release actions with softprops/action-gh-release

### DIFF
--- a/.github/workflows/_dotnet-publish-template.yml
+++ b/.github/workflows/_dotnet-publish-template.yml
@@ -25,28 +25,15 @@ jobs:
       id: vars
       run: echo "sha_short=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_OUTPUT
 
-    - name: Create Draft Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Replaces the old create-release -> upload-release-asset -> publish-release chain
+    # (all three actions are archived and still run on Node 12/20). action-gh-release
+    # creates the release and attaches the asset in one step, so there is no window
+    # where a half-built draft release exists.
+    - name: Create release and attach build
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.vars.outputs.sha_short }}
-        release_name: Holos 4 - ${{ steps.vars.outputs.sha_short }}
-        draft: true
+        name: Holos 4 - ${{ steps.vars.outputs.sha_short }}
+        files: ${{ inputs.filename }}.zip
+        draft: false
         prerelease: false
-
-    - uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ inputs.filename }}.zip
-        asset_name: ${{ inputs.filename }}.zip
-        asset_content_type: application/zip
-
-    - uses: eregon/publish-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        release_id: ${{ steps.create_release.outputs.id }}


### PR DESCRIPTION
Follow-up to #438 (which bumped everything that *could* be bumped). These three couldn't be — they're **archived**, so no newer version exists:

| Action | Runtime | Status |
|---|---|---|
| `actions/create-release@v1` | **node12** | ARCHIVED |
| `actions/upload-release-asset@v1.0.1` | **node12** | ARCHIVED |
| `eregon/publish-release@v1` | node20 | ARCHIVED |

## Change
The old **create-draft → upload-asset → publish** chain (three actions, needed because `create-release` couldn't attach files) collapses into a single **`softprops/action-gh-release@v3`** step, which creates the release *and* attaches the asset in one operation.

**Same end result:** a published release named `Holos 4 - <short-sha>`, tagged with the short SHA, with `Holos4-lib.zip` attached. Bonus: no window where a half-built draft release is visible.

⚠️ **`@v3` specifically** — `action-gh-release@v2` is *still node20* and would have quietly reintroduced the very warning #438 removed.

## Testing note
The publish job only runs on push to `main`, so **no PR check can exercise this** — it'll be proven by the first release run after merge. I've deliberately kept the change minimal to reduce that risk:
- Permissions left untouched (the job's existing default `GITHUB_TOKEN` already creates releases today, and `action-gh-release` needs the same `contents: write`). Adding an explicit `permissions:` block would be good hygiene but would *override* defaults on a job we can't validate pre-merge — better as its own change.
- Token handling is equivalent (`action-gh-release` defaults to `${{ github.token }}`).

Happy to watch the first release run after merge and confirm the release + asset land correctly.