### PR TITLE
Add year-specific grazing check to CropViewItem

### DIFF
--- a/H.Core.Test/Models/LandManagement/Fields/CropViewItemTest.cs
+++ b/H.Core.Test/Models/LandManagement/Fields/CropViewItemTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.ObjectModel;
 using H.Core.Enumerations;
 using H.Core.Models.LandManagement.Fields;
 
@@ -8,7 +9,83 @@ namespace H.Core.Test.Models.LandManagement.Fields
     [TestClass]
     public class CropViewItemTest
     {
+        #region Fields
+
+        private CropViewItem _sut;
+
+        #endregion
+
+        #region Initialization
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _sut = new CropViewItem
+            {
+                Year = 2025,
+                GrazingViewItems = new ObservableCollection<GrazingViewItem>()
+            };
+        }
+
+        #endregion
+
         #region Tests
+
+        [TestMethod]
+        public void HasGrazingItemsForTheCurrentYear_WhenNoGrazingItems_ReturnsFalse()
+        {
+            var result = _sut.HasGrazingItemsForTheCurrentYear();
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void HasGrazingItemsForTheCurrentYear_WhenGrazingItemMatchesYear_ReturnsTrue()
+        {
+            _sut.GrazingViewItems.Add(new GrazingViewItem
+            {
+                Start = new DateTime(_sut.Year, 6, 1)
+            });
+
+            var result = _sut.HasGrazingItemsForTheCurrentYear();
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void HasGrazingItemsForTheCurrentYear_WhenGrazingItemIsFromDifferentYear_ReturnsFalse()
+        {
+            _sut.GrazingViewItems.Add(new GrazingViewItem
+            {
+                Start = new DateTime(_sut.Year - 1, 6, 1)
+            });
+
+            var result = _sut.HasGrazingItemsForTheCurrentYear();
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void HasGrazingItemsForTheCurrentYear_WhenMultipleItemsOnlyOneMatchesYear_ReturnsTrue()
+        {
+            _sut.GrazingViewItems.Add(new GrazingViewItem { Start = new DateTime(_sut.Year - 2, 1, 1) });
+            _sut.GrazingViewItems.Add(new GrazingViewItem { Start = new DateTime(_sut.Year, 8, 15) });
+
+            var result = _sut.HasGrazingItemsForTheCurrentYear();
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void HasGrazingItemsForTheCurrentYear_WhenMultipleItemsNoneMatchYear_ReturnsFalse()
+        {
+            _sut.GrazingViewItems.Add(new GrazingViewItem { Start = new DateTime(_sut.Year - 1, 1, 1) });
+            _sut.GrazingViewItems.Add(new GrazingViewItem { Start = new DateTime(_sut.Year + 1, 1, 1) });
+
+            var result = _sut.HasGrazingItemsForTheCurrentYear();
+
+            Assert.IsFalse(result);
+        }
 
         #endregion
     }

--- a/H.Core/Calculators/Carbon/ICBMCarbonInputCalculator.cs
+++ b/H.Core/Calculators/Carbon/ICBMCarbonInputCalculator.cs
@@ -131,7 +131,7 @@ namespace H.Core.Calculators.Carbon
 
             var result = 0d;
             var moistureContentFraction = currentYearViewItem.MoistureContentOfCrop;
-            var isGrazed = currentYearViewItem.GrazingViewItems.Any();
+            var isGrazed = currentYearViewItem.HasGrazingItemsForTheCurrentYear();
             if (isGrazed)
             {
                 moistureContentFraction = (currentYearViewItem.GrazingViewItems.Average(x => x.MoistureContentAsPercentage) / 100.0);

--- a/H.Core/Models/LandManagement/Fields/CropViewItem.Grazing.cs
+++ b/H.Core/Models/LandManagement/Fields/CropViewItem.Grazing.cs
@@ -58,6 +58,15 @@ namespace H.Core.Models.LandManagement.Fields
             }
         }
 
+        /// <summary>
+        /// Returns true if any <see cref="GrazingViewItem"/> in the collection has a start date that falls within the same year as this <see cref="CropViewItem"/>.
+        /// </summary>
+        /// <returns>True if at least one grazing item exists for the current year, false otherwise.</returns>
+        public bool HasGrazingItemsForTheCurrentYear()
+        {
+            return this.GrazingViewItems.Any(x => x.Start.Year == this.Year);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Added HasGrazingItemsForTheCurrentYear to CropViewItem to verify if any GrazingViewItem matches the current year. Updated ICBMCarbonInputCalculator to use this method for more accurate logic. Introduced CropViewItemTest with unit tests covering various scenarios for the new method.