### PR TITLE
Update test to use current date for year and grazing start

### DIFF
--- a/H.Core.Test/Calculators/Carbon/ICBMCarbonInputCalculatorTest.cs
+++ b/H.Core.Test/Calculators/Carbon/ICBMCarbonInputCalculatorTest.cs
@@ -618,6 +618,8 @@ namespace H.Core.Test.Calculators.Carbon
         [TestMethod]
         public void CalculatePlantCarbonInAgriculturalProductGrazedFieldAndCustomYieldAssignmentMethod()
         {
+            var date = DateTime.Now;
+
             var currentYearViewItem = new CropViewItem()
             {
                 Yield = 1000,
@@ -625,9 +627,10 @@ namespace H.Core.Test.Calculators.Carbon
                 PercentageOfProductYieldReturnedToSoil = 10,
                 CropType = CropType.Barley,
                 MoistureContentOfCrop = 0.12,
+                Year = date.Year,
             };
 
-            currentYearViewItem.GrazingViewItems.Add(new GrazingViewItem());
+            currentYearViewItem.GrazingViewItems.Add(new GrazingViewItem() {Start = date});
             var farm = new Farm();
             farm.YieldAssignmentMethod = YieldAssignmentMethod.Custom;
 

--- a/H.Core.Test/Calculators/Carbon/ICBMCarbonInputCalculatorTest.cs
+++ b/H.Core.Test/Calculators/Carbon/ICBMCarbonInputCalculatorTest.cs
@@ -618,7 +618,7 @@ namespace H.Core.Test.Calculators.Carbon
         [TestMethod]
         public void CalculatePlantCarbonInAgriculturalProductGrazedFieldAndCustomYieldAssignmentMethod()
         {
-            var date = DateTime.Now;
+            var date = new DateTime(DateTime.Now.Year, 1, 1);
 
             var currentYearViewItem = new CropViewItem()
             {


### PR DESCRIPTION
Updated CalculatePlantCarbonInAgriculturalProductGrazedFieldAndCustomYieldAssignmentMethod test to set CropViewItem's Year and GrazingViewItem's Start to the current date. Previously, GrazingViewItem was added without initializing Start.