### PR TITLE
Broaden the lib/ ignore rule to cover any Telerik version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,4 +409,7 @@ build_instructions.js
 Hamiota baseline M19_patched.json
 build_residue_n_calculator.py
 H.Content/Documentation/Crop_Residue_Nitrogen_Calculator.xlsx
-/lib/RCWPF/2018.1.220.45
+# Licensed Telerik/SharpDX binaries. These live in the private GUI repo
+# (holos-aafc/Holos-4-GUI) and are junctioned in locally; they must never
+# be committed here. Broad pattern so a Telerik version bump stays covered.
+/lib/


### PR DESCRIPTION
Small hardening follow-up to a3d66f49.

## Why
a3d66f49 added `/lib/RCWPF/2018.1.220.45` to keep the **licensed Telerik/SharpDX binaries out of this public repo** — the right call. But the pattern is **pinned to the current Telerik version**. If Telerik is ever upgraded, `lib/RCWPF/<new-version>/` would **not** be ignored, and the licensed DLLs could be committed to a public repo by accident.

## Change
```diff
- /lib/RCWPF/2018.1.220.45
+ /lib/
```
…plus a comment noting these binaries live in the private GUI repo (`holos-aafc/Holos-4-GUI`) and are junctioned in locally.

## Verified
With the local `.git/info/exclude` neutralised, so only this committed `.gitignore` applies:

| path | result |
|---|---|
| `lib/RCWPF/2018.1.220.45/Telerik.Windows.Controls.dll` | ignored ✅ |
| `lib/RCWPF/2024.9.9.9/Telerik.Windows.Controls.dll` (future version) | ignored ✅ |
| `lib/SomethingElse/foo.dll` | ignored ✅ |

## No functional change
Public projects don't reference Telerik (only the private `H` views project does), and **0** files under `lib/` are tracked here today.