### PR TITLE
Add SetActiveFarm for making an existing farm active

### DIFF
--- a/H.Core.Test/H.Core.Test.csproj
+++ b/H.Core.Test/H.Core.Test.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Models\TrannumDataTest.cs" />
     <Compile Include="Models\FarmTest.cs" />
     <Compile Include="Models\ApplicationDataFarmReferenceTest.cs" />
+    <Compile Include="Models\SetActiveFarmTest.cs" />
     <Compile Include="Models\PastureLocationRepairTest.cs" />
     <Compile Include="Models\FarmSerializationDuplicationTest.cs" />
     <Compile Include="StorageRoundTripTest.cs" />

--- a/H.Core.Test/Models/SetActiveFarmTest.cs
+++ b/H.Core.Test/Models/SetActiveFarmTest.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using H.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace H.Core.Test.Models
+{
+    /// <summary>
+    /// Opening a farm has to make it the active farm without disturbing the order farms are stored in.
+    /// </summary>
+    [TestClass]
+    public class SetActiveFarmTest
+    {
+        [TestMethod]
+        public void SetActiveFarmAssignsEvenWhenTheCurrentFarmSharesTheGuid()
+        {
+            var settings = new GlobalSettings();
+
+            var farm = new Farm { Name = "Farm" };
+            var separateInstanceWithSameGuid = new Farm { Name = "Copy", Guid = farm.Guid };
+
+            settings.ActiveFarm = separateInstanceWithSameGuid;
+            settings.SetActiveFarm(farm);
+
+            Assert.AreSame(farm, settings.ActiveFarm,
+                "the active farm must be the instance that was passed in, not the one it replaced");
+        }
+
+        [TestMethod]
+        public void AssigningThePropertyDoesNotSwapInstancesSharingAGuid()
+        {
+            // Why SetActiveFarm exists. ModelBase compares by Guid, so SetProperty sees no change here.
+            var settings = new GlobalSettings();
+
+            var farm = new Farm { Name = "Farm" };
+            var separateInstanceWithSameGuid = new Farm { Name = "Copy", Guid = farm.Guid };
+
+            settings.ActiveFarm = separateInstanceWithSameGuid;
+            settings.ActiveFarm = farm;
+
+            Assert.AreSame(separateInstanceWithSameGuid, settings.ActiveFarm,
+                "assigning the property is expected to leave the existing instance in place");
+        }
+
+        [TestMethod]
+        public void MakingAFarmActiveLeavesTheFarmOrderAlone()
+        {
+            var data = new ApplicationData();
+
+            var first = new Farm { Name = "First" };
+            var second = new Farm { Name = "Second" };
+            var third = new Farm { Name = "Third" };
+
+            data.Farms.Add(first);
+            data.Farms.Add(second);
+            data.Farms.Add(third);
+
+            // Open the middle farm, as the open farm dialog does.
+            data.GlobalSettings.SetActiveFarm(second);
+
+            Assert.AreSame(second, data.GlobalSettings.ActiveFarm);
+            CollectionAssert.AreEqual(
+                new[] { "First", "Second", "Third" },
+                data.Farms.Select(x => x.Name).ToArray(),
+                "opening a farm must not move it within the collection");
+        }
+    }
+}

--- a/H.Core/Models/GlobalSettings.cs
+++ b/H.Core/Models/GlobalSettings.cs
@@ -92,6 +92,17 @@ namespace H.Core.Models
         /// </summary>
         internal void RestoreActiveFarm(Farm farm)
         {
+            this.SetActiveFarm(farm);
+        }
+
+        /// <summary>
+        /// Makes <paramref name="farm"/> the active farm. Use this rather than assigning <see cref="ActiveFarm"/> when
+        /// the farm may already be represented by another instance: <see cref="ModelBase.Equals(object)"/> compares by
+        /// <see cref="ModelBase.Guid"/>, so SetProperty treats a swap between two instances sharing a guid as no change
+        /// and leaves the old one in place.
+        /// </summary>
+        public void SetActiveFarm(Farm farm)
+        {
             _activeFarm = farm;
             _activeFarmGuid = farm != null ? farm.Guid : Guid.Empty;
 


### PR DESCRIPTION
Towards #445.

`ModelBase` compares by `Guid`, so assigning `GlobalSettings.ActiveFarm` is treated as no change whenever the current farm shares the incoming farm's guid, and the old instance stays in place. A caller passing a farm that may already be represented by another instance has no way to make the assignment take.

`SetActiveFarm` assigns the field and raises the change notification, which is what the restore after loading already did. `RestoreActiveFarm` now calls it.

This is additive - nothing in this repository calls it yet. The interface change that uses it is in the views repository and will follow once this is merged, so that nobody ends up with a call to a method that is not published.

The other places that assign `ActiveFarm` all pass a newly created farm, so their guids are unique and assigning the property works as written. They are left alone.

## Why it is needed

The open farm dialog worked around this by removing the selected farm from `Farms` and adding it back, which moved it to the end of the list every time a farm was opened. The comment there attributed it to `ObservableCollection` versus `List`, which is not the cause.

The reason the assignment used to fail is that the active farm was read from file as a separate copy of a farm that was also in `Farms` - the duplication removed in #444. With that fixed the assignment now works for a farm the user selects, but only because the active farm happens to be a reference into `Farms`. `SetActiveFarm` makes that explicit rather than relying on it.

## Tests

Three, including one that pins the behaviour the method exists for: assigning the property does not swap between two instances sharing a guid. If that ever changes, the test says so rather than the knowledge being lost again.

H.Core.Test: 1183 passed, 0 failed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
