### PR TITLE
Stop the valid manure state types collection growing on every save

### DIFF
--- a/H.Core.Test/H.Core.Test.csproj
+++ b/H.Core.Test/H.Core.Test.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Models\LandManagement\Fields\ManureApplicationViewItemTest.cs" />
     <Compile Include="Models\LandManagement\Fields\HarvestViewItemTest.cs" />
     <Compile Include="Models\ManureTankTest.cs" />
+    <Compile Include="Models\ManureStateTypesCollectionTest.cs" />
     <Compile Include="Models\TreeGroupDataTest.cs" />
     <Compile Include="Models\RowDataTest.cs" />
     <Compile Include="Models\ShelterbeltComponentTest.cs" />

--- a/H.Core.Test/Models/ManureStateTypesCollectionTest.cs
+++ b/H.Core.Test/Models/ManureStateTypesCollectionTest.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Linq;
+using H.Core.Enumerations;
+using H.Core.Models.Infrastructure;
+using H.Core.Models.LandManagement.Fields;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace H.Core.Test.Models
+{
+    /// <summary>
+    /// The valid-state-type collections are seeded in their constructors, so without ObjectCreationHandling.Replace
+    /// Json.NET adds the values from file on top of the seed and the collection grows by one on every load and save.
+    /// </summary>
+    [TestClass]
+    public class ManureStateTypesCollectionTest
+    {
+        private static JsonSerializer Serializer()
+        {
+            return new JsonSerializer { TypeNameHandling = TypeNameHandling.Auto };
+        }
+
+        private static T RoundTrip<T>(T value)
+        {
+            string json;
+            using (var writer = new StringWriter())
+            {
+                Serializer().Serialize(writer, value, typeof(T));
+                json = writer.ToString();
+            }
+
+            using (var reader = new StringReader(json))
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                return Serializer().Deserialize<T>(jsonReader);
+            }
+        }
+
+        [TestMethod]
+        public void ManureApplicationViewItemStateTypesDoNotGrowOnReload()
+        {
+            var item = new ManureApplicationViewItem();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Clear();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Add(ManureStateType.DeepBedding);
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Add(ManureStateType.Liquid);
+
+            var before = item.ValidManureStateTypesForSelectedTypeOfAnimalManure.ToList();
+
+            var reloaded = RoundTrip(item);
+
+            CollectionAssert.AreEqual(before,
+                reloaded.ValidManureStateTypesForSelectedTypeOfAnimalManure.ToList(),
+                "the collection must come back exactly as saved, with no seeded entry added");
+        }
+
+        [TestMethod]
+        public void ManureSubstrateViewItemStateTypesDoNotGrowOnReload()
+        {
+            var item = new ManureSubstrateViewItem();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Clear();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Add(ManureStateType.DeepBedding);
+
+            var before = item.ValidManureStateTypesForSelectedTypeOfAnimalManure.ToList();
+
+            var reloaded = RoundTrip(item);
+
+            CollectionAssert.AreEqual(before,
+                reloaded.ValidManureStateTypesForSelectedTypeOfAnimalManure.ToList(),
+                "the collection must come back exactly as saved, with no seeded entry added");
+        }
+
+        [TestMethod]
+        public void RepeatedReloadsDoNotAccumulateEntries()
+        {
+            var item = new ManureApplicationViewItem();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Clear();
+            item.ValidManureStateTypesForSelectedTypeOfAnimalManure.Add(ManureStateType.Solid);
+
+            var once = RoundTrip(item);
+            var twice = RoundTrip(once);
+            var thrice = RoundTrip(twice);
+
+            Assert.AreEqual(1, thrice.ValidManureStateTypesForSelectedTypeOfAnimalManure.Count,
+                "the collection grew across repeated load and save cycles");
+        }
+    }
+}

--- a/H.Core/Models/Infrastructure/ManureSubstrateViewItem.cs
+++ b/H.Core/Models/Infrastructure/ManureSubstrateViewItem.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using H.Core.Enumerations;
 using H.Core.Providers.Animals;
 using H.Infrastructure;
+using Newtonsoft.Json;
 
 namespace H.Core.Models.Infrastructure
 {
@@ -43,6 +44,12 @@ namespace H.Core.Models.Infrastructure
         /// <summary>
         /// Each view item must have its own collection of valid state types so the table rows presented to the user will have their own distinct collection
         /// </summary>
+        /// <remarks>
+        /// Replace rather than populate on read. The constructor seeds this with NotSelected, and Json.NET's default
+        /// handling for a collection property adds the values from file to whatever is already there, so the seeded
+        /// entry accumulated and the collection grew by one on every load and save.
+        /// </remarks>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
         public ObservableCollection<ManureStateType> ValidManureStateTypesForSelectedTypeOfAnimalManure
         {
             get => _validManureStateTypesForSelectedTypeOfAnimalManure;

--- a/H.Core/Models/LandManagement/Fields/ManureItemBase.cs
+++ b/H.Core/Models/LandManagement/Fields/ManureItemBase.cs
@@ -5,6 +5,7 @@ using H.Core.CustomAttributes;
 using H.Core.Enumerations;
 using H.Core.Providers.Animals;
 using H.Infrastructure;
+using Newtonsoft.Json;
 
 namespace H.Core.Models.LandManagement.Fields
 {
@@ -82,6 +83,12 @@ namespace H.Core.Models.LandManagement.Fields
         /// <summary>
         /// Each view item must have its own collection of valid state types so the table rows presented to the user will have their own distinct collection
         /// </summary>
+        /// <remarks>
+        /// Replace rather than populate on read. The constructor seeds this with NotSelected, and Json.NET's default
+        /// handling for a collection property adds the values from file to whatever is already there, so the seeded
+        /// entry accumulated and the collection grew by one on every load and save.
+        /// </remarks>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
         public ObservableCollection<ManureStateType> ValidManureStateTypesForSelectedTypeOfAnimalManure
         {
             get => _validManureStateTypesForSelectedTypeOfAnimalManure;


### PR DESCRIPTION
The last of the per-save file growth. A farm loaded and saved twice produced files that differed, and the difference was one extra entry in a manure collection each cycle. This finishes what #444 started.

## What was wrong

`ManureItemBase` and `ManureSubstrateViewItem` seed `ValidManureStateTypesForSelectedTypeOfAnimalManure` with `NotSelected` in their constructors. Json.NET's default handling for a collection property adds the values read from file on top of whatever the getter already holds, so the seeded entry accumulated and the collection gained one element on every load and save.

```
saved once:  "ValidManureStateTypes...":[0,...,0,6]      29 entries
saved twice: "ValidManureStateTypes...":[0,...,0,0,6]    30 entries
```

Marking both properties with `ObjectCreationHandling.Replace` makes the values from file replace the seed. The same real farm now round-trips to a byte-identical file.

## Same pattern as before

This is the third instance of a constructor-seeded collection accumulating on load - the review of #444 found the same thing in `FarmsForComparisonGuids`. Any serialized collection property whose constructor pre-populates it has this behaviour. I scanned H.Core for collection initializers seeded with elements; these two are the only serialized model properties among them (the rest are local variables, private provider tables, or collections built empty).

## Tests

Cover both classes and a three-cycle reload. All fail without the change; the three-cycle case reaches four entries where it should hold one.

H.Core.Test: 1186 passed, 0 failed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
