### PR TITLE
Restore lower-bound validation on GetMonthFromJulianDay

### DIFF
--- a/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
+++ b/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
@@ -124,5 +124,23 @@ namespace H.Core.Test.Services.LandManagement
             var result = _sut.GetMonthFromJulianDay(julianDay, year);
             Assert.AreEqual(expectedMonth, result);
         }
+
+        [DataTestMethod]
+        [DataRow(0, 2021)]
+        [DataRow(-1, 2021)]
+        [DataRow(366, 2021)] // 2021 is not a leap year, so day 366 does not exist
+        [DataRow(367, 2024)] // beyond even a leap year
+        public void GetMonthFromJulianDayThrowsForDaysOutsideTheYear(int julianDay, int year)
+        {
+            Assert.ThrowsException<Exception>(() => _sut.GetMonthFromJulianDay(julianDay, year));
+        }
+
+        [TestMethod]
+        public void GetMonthFromJulianDayAcceptsTheFirstAndLastDayOfTheYear()
+        {
+            Assert.AreEqual(Months.January, _sut.GetMonthFromJulianDay(1, 2021), "day 1 must be valid");
+            Assert.AreEqual(Months.December, _sut.GetMonthFromJulianDay(365, 2021), "the last day of a common year must be valid");
+            Assert.AreEqual(Months.December, _sut.GetMonthFromJulianDay(366, 2024), "the last day of a leap year must be valid");
+        }
     }
 }

--- a/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
+++ b/H.Core.Test/Services/LandManagement/IrrigationServiceTest.cs
@@ -132,7 +132,7 @@ namespace H.Core.Test.Services.LandManagement
         [DataRow(367, 2024)] // beyond even a leap year
         public void GetMonthFromJulianDayThrowsForDaysOutsideTheYear(int julianDay, int year)
         {
-            Assert.ThrowsException<Exception>(() => _sut.GetMonthFromJulianDay(julianDay, year));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _sut.GetMonthFromJulianDay(julianDay, year));
         }
 
         [TestMethod]

--- a/H.Core/Services/LandManagement/IrrigationService.cs
+++ b/H.Core/Services/LandManagement/IrrigationService.cs
@@ -154,7 +154,10 @@ namespace H.Core.Services.LandManagement
             var daysInYear = DateTime.IsLeapYear(year) ? 366 : 365;
             if (julianDay < 1 || julianDay > daysInYear)
             {
-                throw new Exception($"Julian day out of range: {julianDay}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(julianDay),
+                    julianDay,
+                    $"Julian day must be between 1 and {daysInYear} for year {year}.");
             }
 
             return (Months)new DateTime(year, 1, 1)

--- a/H.Core/Services/LandManagement/IrrigationService.cs
+++ b/H.Core/Services/LandManagement/IrrigationService.cs
@@ -151,7 +151,8 @@ namespace H.Core.Services.LandManagement
 
         public Months GetMonthFromJulianDay(int julianDay, int year)
         {
-            if (julianDay > (DateTime.IsLeapYear(year) ? 366 : 365))
+            var daysInYear = DateTime.IsLeapYear(year) ? 366 : 365;
+            if (julianDay < 1 || julianDay > daysInYear)
             {
                 throw new Exception($"Julian day out of range: {julianDay}");
             }


### PR DESCRIPTION
Follows #433.

#433 replaced the hand-rolled month lookup - which threw for any julian day outside 1..366 - with `DateTime`-based logic that checks only the upper bound. A day below 1 no longer throws; it rolls into the previous year and returns a month from it.

No caller passes such a value today (the internal loop starts at 1 and there are no external callers), so this is not a live bug. It restores the public method's original contract of rejecting out-of-range input rather than silently returning a wrong-year month.

The lower bound is folded into the existing range check. Tests cover days below 1, days beyond the year's length, and the first and last valid day of both a common and a leap year. The two lower-bound cases fail without the guard; the upper-bound cases pass either way, since that check already existed.

H.Core.Test: 1206 passed, 0 failed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
