### PR TITLE
Add a per-application manure NH3-N emission factor report

### DIFF
--- a/H.Core.Test/H.Core.Test.csproj
+++ b/H.Core.Test/H.Core.Test.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Services\DairyCattleResultsServiceTest.cs" />
     <Compile Include="Services\FarmResultsServiceTest.cs" />
     <Compile Include="Services\FieldResultsServiceTest.cs" />
+    <Compile Include="Services\FieldResultsServiceTest.ManureNH3Report.cs" />
     <Compile Include="Providers\Climate\BuildNewSLCClimateNorms.cs" />
     <Compile Include="Services\AnimalComponentHelperTest.cs" />
     <Compile Include="Services\Initialization\CropInitializationServiceTest.cs" />

--- a/H.Core.Test/Services/FieldResultsServiceTest.ManureNH3Report.cs
+++ b/H.Core.Test/Services/FieldResultsServiceTest.ManureNH3Report.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using H.Core.Enumerations;
+using H.Core.Models;
+using H.Core.Models.LandManagement.Fields;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace H.Core.Test.Services
+{
+    public partial class FieldResultsServiceTest
+    {
+        #region Manure land-application NH3-N emission factor report
+
+        private static ManureApplicationViewItem PoultryApplication(int month, double nitrogenPerHectare)
+        {
+            return new ManureApplicationViewItem
+            {
+                AnimalType = AnimalType.Broilers,
+                ManureLocationSourceType = ManureLocationSourceType.Livestock,
+                ManureStateType = ManureStateType.Solid,
+                DateOfApplication = new System.DateTime(2024, month, 15),
+                AmountOfNitrogenAppliedPerHectare = nitrogenPerHectare,
+            };
+        }
+
+        /// <summary>The report gives every manure application its own row, so several applications on one field-year are not merged.</summary>
+        [TestMethod]
+        public void ManureReport_WritesOneRowPerApplication()
+        {
+            // No rain, so the poultry EF is the base tillage/month value with no modifier.
+            _n2OEmissionFactorCalculator.ClimateProvider = base._mockClimateProviderObject;
+
+            var farm = new Farm { Name = "Test farm" };
+            var viewItem = new CropViewItem
+            {
+                Name = "Barley",
+                Year = 2024,
+                Area = 10,
+                TillageType = TillageType.Reduced,
+            };
+            viewItem.ManureApplicationViewItems.Add(PoultryApplication(month: 5, nitrogenPerHectare: 30));  // May  -> 0.42
+            viewItem.ManureApplicationViewItems.Add(PoultryApplication(month: 9, nitrogenPerHectare: 40));  // Sept -> 0.47
+
+            var report = _resultsService.BuildManureLandApplicationEmissionFactorReport(
+                new[] { viewItem }, farm, CultureInfo.InvariantCulture);
+
+            var lines = report.Split('\n').Where(x => x.Trim().Length > 0).ToList();
+
+            // sep line + header + two data rows.
+            var dataRows = lines.Where(x => x.Contains("Test farm")).ToList();
+            Assert.AreEqual(2, dataRows.Count, "each application must have its own row");
+        }
+
+        [TestMethod]
+        public void ManureReport_ReportsTheFinalEmissionFactorForEachApplication()
+        {
+            _n2OEmissionFactorCalculator.ClimateProvider = base._mockClimateProviderObject;
+
+            var farm = new Farm { Name = "Test farm" };
+            var viewItem = new CropViewItem
+            {
+                Name = "Barley",
+                Year = 2024,
+                Area = 10,
+                TillageType = TillageType.Reduced,
+            };
+            viewItem.ManureApplicationViewItems.Add(PoultryApplication(month: 5, nitrogenPerHectare: 30));  // May  -> 0.42
+            viewItem.ManureApplicationViewItems.Add(PoultryApplication(month: 9, nitrogenPerHectare: 40));  // Sept -> 0.47
+
+            var report = _resultsService.BuildManureLandApplicationEmissionFactorReport(
+                new[] { viewItem }, farm, CultureInfo.InvariantCulture);
+
+            var dataRows = report.Split('\n').Where(x => x.Contains("Test farm")).ToList();
+
+            var mayRow = dataRows.Single(x => x.Contains("2024-05-15"));
+            var septemberRow = dataRows.Single(x => x.Contains("2024-09-15"));
+
+            // Poultry EF acts on TAN, so the basis column must say so, and the final EF must match the box values.
+            Assert.IsTrue(mayRow.Contains("0.4200"), "May application (tilled, May-Aug) must report 0.42");
+            Assert.IsTrue(septemberRow.Contains("0.4700"), "September application (tilled, Apr/Sep/Oct) must report 0.47");
+            Assert.IsTrue(mayRow.Contains(Properties.Resources.LabelPerKilogramTan),
+                "a poultry emission factor is applied per kg TAN");
+        }
+
+        [TestMethod]
+        public void ManureReport_HasAHeaderAndNoDataRowsWhenThereAreNoApplications()
+        {
+            var farm = new Farm { Name = "Test farm" };
+            var viewItem = new CropViewItem { Name = "Barley", Year = 2024, Area = 10 };
+
+            var report = _resultsService.BuildManureLandApplicationEmissionFactorReport(
+                new[] { viewItem }, farm, CultureInfo.InvariantCulture);
+
+            Assert.IsTrue(report.Contains(Properties.Resources.LabelFinalAmmoniaEmissionFactorForLandApplication),
+                "the header must always be written");
+            Assert.IsFalse(report.Contains("Test farm"),
+                "a field-year with no manure applications produces no rows");
+        }
+
+        #endregion
+    }
+}

--- a/H.Core/Calculators/Nitrogen/N2OEmissionFactorCalculator.Manure.cs
+++ b/H.Core/Calculators/Nitrogen/N2OEmissionFactorCalculator.Manure.cs
@@ -360,63 +360,98 @@ namespace H.Core.Calculators.Nitrogen
         /// (kg NH3-N)
         /// </summary>
         public double CalculateNH3NLossFromLandAppliedManure(
-            Farm farm, 
+            Farm farm,
             CropViewItem viewItem,
             ManureApplicationViewItem manureApplicationViewItem)
         {
-            var result = 0d;
+            var emissionFactor = this.GetFinalAmmoniaEmissionFactorForLandApplication(farm, viewItem, manureApplicationViewItem);
 
-            if (manureApplicationViewItem.IsImportedManure()) 
+            // Beef, dairy and poultry emission factors act on the applied TAN; every other source (sheep, swine, other
+            // livestock and imported manure) acts on the applied nitrogen.
+            if (AppliesEmissionFactorToTan(manureApplicationViewItem))
             {
-                var landApplicationFactors = this.GetLandApplicationFactors(farm, manureApplicationViewItem);
-                var nitrogenUsed = manureApplicationViewItem.AmountOfNitrogenAppliedPerHectare * viewItem.Area;
+                var tanUsed = _manureService.GetAmountOfTanUsedDuringLandApplication(viewItem, manureApplicationViewItem);
+                return tanUsed * emissionFactor;
+            }
 
-                result = nitrogenUsed * landApplicationFactors.VolatilizationFraction;
+            var nitrogenUsed = manureApplicationViewItem.AmountOfNitrogenAppliedPerHectare * viewItem.Area;
+            return nitrogenUsed * emissionFactor;
+        }
 
-                return result;
+        /// <summary>
+        /// Returns the final NH3-N emission factor used to estimate ammonia losses from a single land application of
+        /// manure, i.e. the multiplier applied by <see cref="CalculateNH3NLossFromLandAppliedManure"/> before it is
+        /// multiplied by the applied TAN or nitrogen.
+        ///
+        /// The value's basis depends on the manure source (see <see cref="AppliesEmissionFactorToTan"/>): beef, dairy
+        /// and poultry factors are per kg TAN; sheep, swine, other livestock and imported manure factors are per kg N.
+        /// </summary>
+        /// <remarks>
+        /// Equation 4.6.2-3 (beef/dairy), Equation 4.6.2-12 (sheep/swine/other and imported), and the poultry box in
+        /// section 4.6.2 (broilers, layers and turkeys; Sheppard et al. 2009b, Tables 5 and 6).
+        /// </remarks>
+        public double GetFinalAmmoniaEmissionFactorForLandApplication(
+            Farm farm,
+            CropViewItem viewItem,
+            ManureApplicationViewItem manureApplicationViewItem)
+        {
+            if (manureApplicationViewItem.IsImportedManure())
+            {
+                return this.GetLandApplicationFactors(farm, manureApplicationViewItem).VolatilizationFraction;
             }
 
             var animalType = manureApplicationViewItem.AnimalType;
             if (animalType.IsBeefCattleType() || animalType.IsDairyCattleType())
             {
                 // Equation 4.6.2-3
-                var adjustedAmmoniaEmissionFactor = this.GetAdjustedAmmoniaEmissionFactor(farm, viewItem, manureApplicationViewItem);
-                var tanUsed = _manureService.GetAmountOfTanUsedDuringLandApplication(viewItem, manureApplicationViewItem);
-                result = tanUsed * adjustedAmmoniaEmissionFactor;
+                return this.GetAdjustedAmmoniaEmissionFactor(farm, viewItem, manureApplicationViewItem);
             }
-            else if (animalType.IsSheepType() || animalType.IsSwineType() || animalType.IsOtherAnimalType())
-            {
-                var landApplicationFactors = this.GetLandApplicationFactors(farm, manureApplicationViewItem);
-                var nitrogenUsed = manureApplicationViewItem.AmountOfNitrogenAppliedPerHectare * viewItem.Area;
 
+            if (animalType.IsSheepType() || animalType.IsSwineType() || animalType.IsOtherAnimalType())
+            {
                 // Equation 4.6.2-12
-                result = nitrogenUsed * landApplicationFactors.VolatilizationFraction;
+                return this.GetLandApplicationFactors(farm, manureApplicationViewItem).VolatilizationFraction;
             }
-            else
+
+            // Broilers, layers and turkeys — Eq. 4.6.2 (Sheppard et al. 2009b, Table 6)
+            // EF(tillage, month) [× rain modifier if it rained the day after application]
+            var applicationDate = manureApplicationViewItem.DateOfApplication;
+            var baseEf = this.GetPoultryLandApplicationEmissionFactor(viewItem.TillageType, applicationDate.Month);
+
+            // If precipitation occurs within 1 day of application, multiply EF by the temperature-dependent rain
+            // modification factor (Sheppard et al. 2009b, Table 5; original source: Brentrup et al. 2000, Table 5).
+            // T is the mean daily temperature on the day rain occurs (i.e., the day after application).
+            var dayAfterApplication = applicationDate.AddDays(1);
+            var precipitationDayAfter = this.ClimateProvider.GetMeanPrecipitationForDay(farm, dayAfterApplication);
+            if (precipitationDayAfter > 0)
             {
-                // Broilers, layers and turkeys — Eq. 4.6.2 (Sheppard et al. 2009b, Table 6)
-                // NH3-N = EF(tillage, month) [× rain modifier if it rained the day after application] × TAN
-                var tanUsed = _manureService.GetAmountOfTanUsedDuringLandApplication(viewItem, manureApplicationViewItem);
-                var applicationDate = manureApplicationViewItem.DateOfApplication;
-
-                var baseEf = this.GetPoultryLandApplicationEmissionFactor(viewItem.TillageType, applicationDate.Month);
-
-                // If precipitation occurs within 1 day of application, multiply EF by the
-                // temperature-dependent rain modification factor (Sheppard et al. 2009b, Table 5;
-                // original source: Brentrup et al. 2000, Table 5).
-                // T is the mean daily temperature on the day rain occurs (i.e., the day after application).
-                var dayAfterApplication = applicationDate.AddDays(1);
-                var precipitationDayAfter = this.ClimateProvider.GetMeanPrecipitationForDay(farm, dayAfterApplication);
-                if (precipitationDayAfter > 0)
-                {
-                    var temperatureDayAfter = this.ClimateProvider.GetMeanTemperatureForDay(farm, dayAfterApplication);
-                    baseEf *= this.GetRainModificationFactorForPoultryManure(temperatureDayAfter);
-                }
-
-                result = baseEf * tanUsed;
+                var temperatureDayAfter = this.ClimateProvider.GetMeanTemperatureForDay(farm, dayAfterApplication);
+                baseEf *= this.GetRainModificationFactorForPoultryManure(temperatureDayAfter);
             }
 
-            return result;
+            return baseEf;
+        }
+
+        /// <summary>
+        /// True when the land-application emission factor for <paramref name="manureApplicationViewItem"/> is applied to
+        /// the applied TAN (beef, dairy and poultry); false when it is applied to the applied nitrogen (sheep, swine,
+        /// other livestock and imported manure).
+        /// </summary>
+        public static bool AppliesEmissionFactorToTan(ManureApplicationViewItem manureApplicationViewItem)
+        {
+            if (manureApplicationViewItem.IsImportedManure())
+            {
+                return false;
+            }
+
+            var animalType = manureApplicationViewItem.AnimalType;
+            if (animalType.IsSheepType() || animalType.IsSwineType() || animalType.IsOtherAnimalType())
+            {
+                return false;
+            }
+
+            // Beef, dairy and poultry (broilers, layers, turkeys).
+            return true;
         }
 
         /// <summary>

--- a/H.Core/H.Core.csproj
+++ b/H.Core/H.Core.csproj
@@ -737,6 +737,7 @@
     <Compile Include="Services\LandManagement\FieldResultsService.EstimatesOfProduction.cs" />
     <Compile Include="Services\LandManagement\FieldResultsService.Perennials.cs" />
     <Compile Include="Services\LandManagement\FieldResultsService.FileExport.cs" />
+    <Compile Include="Services\LandManagement\FieldResultsService.ManureNH3Report.cs" />
     <Compile Include="Services\LandManagement\FieldResultsService.UnderSownCrops.cs" />
     <Compile Include="Services\LandManagement\IFieldResultsService.cs" />
     <Compile Include="Services\LandManagement\Shelterbelts\IShelterbeltComponentHelper.cs" />

--- a/H.Core/Properties/Resources.Designer.cs
+++ b/H.Core/Properties/Resources.Designer.cs
@@ -18934,5 +18934,86 @@ namespace H.Core.Properties {
                 return ResourceManager.GetString("Yukon", resourceCulture);
             }
         }
-    }
+            
+        /// <summary>
+        ///   Looks up a localized string similar to Date of Application.
+        /// </summary>
+        public static string LabelDateOfApplication {
+            get {
+                return ResourceManager.GetString("LabelDateOfApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Imported.
+        /// </summary>
+        public static string Imported {
+            get {
+                return ResourceManager.GetString("Imported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manure Source.
+        /// </summary>
+        public static string LabelManureSource {
+            get {
+                return ResourceManager.GetString("LabelManureSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nitrogen Applied (kg N ha-1).
+        /// </summary>
+        public static string LabelAmountOfNitrogenApplied {
+            get {
+                return ResourceManager.GetString("LabelAmountOfNitrogenApplied", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Emission Factor Basis.
+        /// </summary>
+        public static string LabelEmissionFactorBasis {
+            get {
+                return ResourceManager.GetString("LabelEmissionFactorBasis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Final NH3-N Emission Factor for Land Application.
+        /// </summary>
+        public static string LabelFinalAmmoniaEmissionFactorForLandApplication {
+            get {
+                return ResourceManager.GetString("LabelFinalAmmoniaEmissionFactorForLandApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to per kg TAN.
+        /// </summary>
+        public static string LabelPerKilogramTan {
+            get {
+                return ResourceManager.GetString("LabelPerKilogramTan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to per kg N.
+        /// </summary>
+        public static string LabelPerKilogramNitrogen {
+            get {
+                return ResourceManager.GetString("LabelPerKilogramNitrogen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Livestock.
+        /// </summary>
+        public static string LabelLivestock {
+            get {
+                return ResourceManager.GetString("LabelLivestock", resourceCulture);
+            }
+        }
+}
 }

--- a/H.Core/Properties/Resources.resx
+++ b/H.Core/Properties/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -6438,5 +6438,32 @@ Please note: emissions related to the deposition or application of livestock man
   </data>
   <data name="KilogramsN2ONPerHeadPerDay" xml:space="preserve">
     <value>kg N2O-N head^-1 day^-1</value>
+  </data>
+  <data name="LabelDateOfApplication" xml:space="preserve">
+    <value>Date of Application</value>
+  </data>
+  <data name="Imported" xml:space="preserve">
+    <value>Imported</value>
+  </data>
+  <data name="LabelManureSource" xml:space="preserve">
+    <value>Manure Source</value>
+  </data>
+  <data name="LabelAmountOfNitrogenApplied" xml:space="preserve">
+    <value>Nitrogen Applied (kg N ha-1)</value>
+  </data>
+  <data name="LabelEmissionFactorBasis" xml:space="preserve">
+    <value>Emission Factor Basis</value>
+  </data>
+  <data name="LabelFinalAmmoniaEmissionFactorForLandApplication" xml:space="preserve">
+    <value>Final NH3-N Emission Factor for Land Application</value>
+  </data>
+  <data name="LabelPerKilogramTan" xml:space="preserve">
+    <value>per kg TAN</value>
+  </data>
+  <data name="LabelPerKilogramNitrogen" xml:space="preserve">
+    <value>per kg N</value>
+  </data>
+  <data name="LabelLivestock" xml:space="preserve">
+    <value>Livestock</value>
   </data>
 </root>

--- a/H.Core/Services/LandManagement/FieldResultsService.ManureNH3Report.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.ManureNH3Report.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using H.Core.Calculators.Nitrogen;
+using H.Core.Models;
+using H.Core.Models.LandManagement.Fields;
+using H.Infrastructure;
+
+namespace H.Core.Services.LandManagement
+{
+    public partial class FieldResultsService
+    {
+        #region Manure land-application NH3-N emission factor report
+
+        /// <summary>
+        /// Builds a report of the final NH3-N emission factor used for each land application of manure, with one row per
+        /// application. This is the per-application companion to the field results file: because a field-year can have
+        /// several manure applications - each with its own animal type, date and emission factor - a single field-year
+        /// row cannot represent them without ambiguity, so each application is given its own row here with the context
+        /// needed to interpret its emission factor.
+        ///
+        /// The emission factor's basis differs by manure source (see
+        /// <see cref="N2OEmissionFactorCalculator.AppliesEmissionFactorToTan"/>): beef, dairy and poultry factors are
+        /// per kg TAN; sheep, swine, other livestock and imported manure factors are per kg N. The basis is written in
+        /// its own column so the two are never confused.
+        /// </summary>
+        public string BuildManureLandApplicationEmissionFactorReport(
+            IEnumerable<CropViewItem> viewItems,
+            Farm farm,
+            CultureInfo culture)
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendLine("sep =,");
+            stringBuilder.AppendLine(string.Join(",",
+                Properties.Resources.LabelFarm,
+                Properties.Resources.LabelField,
+                Properties.Resources.LabelTimePeriod,
+                Properties.Resources.LabelYear,
+                Properties.Resources.LabelCrop,
+                Properties.Resources.LabelAnimalType,
+                Properties.Resources.LabelManureSource,
+                Properties.Resources.LabelManureType,
+                Properties.Resources.LabelDateOfApplication,
+                Properties.Resources.LabelTillageType,
+                Properties.Resources.LabelAmountOfNitrogenApplied,
+                Properties.Resources.LabelEmissionFactorBasis,
+                Properties.Resources.LabelFinalAmmoniaEmissionFactorForLandApplication));
+
+            foreach (var viewItem in viewItems)
+            {
+                var fieldName = string.IsNullOrWhiteSpace(viewItem.Name) ? viewItem.FieldName : viewItem.Name;
+
+                foreach (var manureApplication in viewItem.ManureApplicationViewItems)
+                {
+                    var emissionFactor = _n2OEmissionFactorCalculator
+                        .GetFinalAmmoniaEmissionFactorForLandApplication(farm, viewItem, manureApplication);
+
+                    var basis = N2OEmissionFactorCalculator.AppliesEmissionFactorToTan(manureApplication)
+                        ? Properties.Resources.LabelPerKilogramTan
+                        : Properties.Resources.LabelPerKilogramNitrogen;
+
+                    var source = manureApplication.IsImportedManure()
+                        ? Properties.Resources.Imported
+                        : Properties.Resources.LabelLivestock;
+
+                    stringBuilder.AppendLine(string.Join(",",
+                        Quote(farm.Name, culture),
+                        Quote(fieldName, culture),
+                        Quote(viewItem.TimePeriodCategoryString, culture),
+                        Quote(viewItem.Year.ToString(culture), culture),
+                        Quote(viewItem.CropTypeString, culture),
+                        Quote(manureApplication.AnimalType.GetDescription(), culture),
+                        Quote(source, culture),
+                        Quote(manureApplication.ManureStateType.GetDescription(), culture),
+                        Quote(manureApplication.DateOfApplication.ToString("yyyy-MM-dd", culture), culture),
+                        Quote(viewItem.TillageType.GetDescription(), culture),
+                        Quote(manureApplication.AmountOfNitrogenAppliedPerHectare.ToString("F4", culture), culture),
+                        Quote(basis, culture),
+                        Quote(emissionFactor.ToString("F4", culture), culture)));
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Writes the report from <see cref="BuildManureLandApplicationEmissionFactorReport"/> to
+        /// <paramref name="path"/>. Returns true on success.
+        /// </summary>
+        public bool ExportManureLandApplicationEmissionFactorReportToFile(
+            IEnumerable<CropViewItem> viewItems,
+            Farm farm,
+            string path,
+            CultureInfo culture)
+        {
+            var contents = this.BuildManureLandApplicationEmissionFactorReport(viewItems, farm, culture);
+
+            try
+            {
+                File.WriteAllText(path, contents, Encoding.UTF8);
+            }
+            catch (IOException exception)
+            {
+                Trace.TraceInformation(
+                    $"{nameof(FieldResultsService)}.{nameof(this.ExportManureLandApplicationEmissionFactorReportToFile)}: " +
+                    $"error writing data to csv file: '{exception.Message}'.");
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Wraps a value in double quotes for CSV output, escaping any embedded quotes.
+        /// </summary>
+        private static string Quote(string value, CultureInfo culture)
+        {
+            var text = value ?? string.Empty;
+            return "\"" + text.Replace("\"", "\"\"") + "\"";
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Addresses a user request to see the final NH3-N emission factor used for land-applied manure - for example the poultry factor from the box in section 4.6.2 of the algorithm document.

## Why a new report rather than a column

The factor is per manure application, but the field results file has one row per field-year, and a field-year can have several applications with different factors (different animal type, month, tillage). There is no unambiguous way to show several per-application factors in a single field-year cell. So this adds a dedicated report with **one row per manure application**, each carrying the context needed to read its factor.

Columns: farm, field, time period, year, crop, animal type, manure source, manure type, application date, tillage, nitrogen applied, emission factor basis, final NH3-N emission factor.

```
"Sample Farm","Barley","Current","2024","Barley","Broilers","Livestock","Solid","2024-05-15","Reduced tillage","30.0000","per kg TAN","0.4200"
"Sample Farm","Barley","Current","2024","Barley","Broilers","Livestock","Solid","2024-09-15","Reduced tillage","40.0000","per kg TAN","0.4700"
```

The factor's basis differs by source - beef, dairy and poultry are per kg TAN; sheep, swine, other livestock and imported manure are per kg N - so the basis is written in its own column and never mixed.

## Behaviour-preserving refactor

The final factor was computed inline inside `CalculateNH3NLossFromLandAppliedManure` and never exposed. It is extracted into a public `GetFinalAmmoniaEmissionFactorForLandApplication`; the loss method now calls it and multiplies by the applied TAN or nitrogen, with the split captured in `AppliesEmissionFactorToTan`. The 66 existing NH3-N loss tests pass unchanged, so the extraction changes no results.

## Scope

- This is the H.Core report generation only. A new export button on the manure modelling report view, in the H project, will follow in a separate change so it does not reference an unpublished method.
- Header strings are English only for now; the French resource file is not updated, so French mode falls back to English headers.

## Tests

Report structure, one-row-per-application, and the box factor values (0.42 May, 0.47 September). The 0.69/0.47/0.42 tillage factors and the rain modifiers were already covered by existing tests.

H.Core.Test: 1209 passed, 0 failed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
