### PR TITLE
Expose the manure NH3-N emission factor report on IFieldResultsService

### DIFF
--- a/H.Core/Services/LandManagement/IFieldResultsService.cs
+++ b/H.Core/Services/LandManagement/IFieldResultsService.cs
@@ -25,6 +25,15 @@ namespace H.Core.Services.LandManagement
                                             string languageAddOn,
                                             bool exportedFromGui,
                                             Farm farm);
+
+        /// <summary>
+        /// Writes the per-application manure NH3-N emission factor report to <paramref name="path"/>. Returns true on
+        /// success. See <see cref="FieldResultsService.BuildManureLandApplicationEmissionFactorReport"/> for the report.
+        /// </summary>
+        bool ExportManureLandApplicationEmissionFactorReportToFile(IEnumerable<CropViewItem> viewItems,
+                                            Farm farm,
+                                            string path,
+                                            CultureInfo culture);
         double CalculateHarvest(CropViewItem viewItem);
 
         FieldSystemDetailsStageState GetStageState(Farm farm);


### PR DESCRIPTION
Follows #449.

The per-application manure NH3-N emission factor report exporter was added to the `FieldResultsService` class in #449, but not to `IFieldResultsService`. Callers that hold the interface - including the field results view models that will host the export button - could not reach it.

Add `ExportManureLandApplicationEmissionFactorReportToFile` to the interface. The class already implements it, so there is no other change.

This unblocks the export button on the multi-year modelling report view, which is a separate change in the views repository (it must not reference the method until this is merged).

Existing report and field-results tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
