### PR TITLE
Fix #434: scope Eq. 4.1.3-6 VS removal fraction to matching manure state type

### DIFF
--- a/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
+++ b/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
@@ -228,8 +228,9 @@ namespace H.Core.Test.Services.Animals
         /// When querying a LiquidNoCrust system, removals from a DeepPit tank are excluded because each state type
         /// represents a distinct storage tank (Eq. 4.1.3-6, issue #434).
         /// </summary>
-[TestMethod]
-public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesDeepPitRemovalsWhenQueryingLiquidNoCrust()
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesDeepPitRemovalsWhenQueryingLiquidNoCrust()
+        {
             // Arrange: all removals on this day are from a DeepPit tank.
             var day = new DateTime(2025, 6, 1);
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.DeepPit);

--- a/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
+++ b/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
@@ -225,69 +225,175 @@ namespace H.Core.Test.Services.Animals
         }
 
         /// <summary>
-        /// When querying a liquid system, solid manure removals are excluded because liquid and solid manure are held
-        /// in separate storage (Eq. 4.1.3-6, issue #434). A solid application must not draw down the liquid tank.
+        /// When querying a LiquidNoCrust system, removals from a DeepPit tank are excluded because each state type
+        /// represents a distinct storage tank (Eq. 4.1.3-6, issue #434).
         /// </summary>
         [TestMethod]
         public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesSolidRemovalsWhenQueryingLiquidSystem()
         {
-            // Arrange: all removals on this day are solid manure.
+            // Arrange: all removals on this day are from a DeepPit tank.
             var day = new DateTime(2025, 6, 1);
-            var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.Solid);
+            var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.DeepPit);
 
-            // Act: query the liquid system for that day.
+            // Act: query a LiquidNoCrust system — a different distinct tank.
             var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
 
-            // Assert: no liquid removals occurred, so nothing is drawn down from the liquid tank.
+            // Assert: DeepPit removals must not draw down the LiquidNoCrust tank.
             Assert.AreEqual(0, result, 1e-9);
         }
 
         /// <summary>
-        /// When querying a solid system, liquid manure removals are excluded for the same separate-storage reason.
+        /// When querying a Solid system, removals from a LiquidNoCrust tank are excluded for the same distinct-tank reason.
         /// </summary>
         [TestMethod]
         public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesLiquidRemovalsWhenQueryingSolidSystem()
         {
-            // Arrange: all removals on this day are liquid manure.
+            // Arrange: all removals on this day are from a LiquidNoCrust tank.
             var day = new DateTime(2025, 6, 1);
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.LiquidNoCrust);
 
-            // Act: query the solid system for that day.
+            // Act: query the Solid system for that day.
             var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.Solid);
 
-            // Assert: no solid removals occurred.
+            // Assert: no Solid removals occurred.
             Assert.AreEqual(0, result, 1e-9);
         }
 
         /// <summary>
-        /// Querying a liquid system counts only the liquid removals when both liquid and solid removals occur on the
-        /// same day for the same animal type.
+        /// Querying a LiquidNoCrust system counts only LiquidNoCrust removals when both LiquidNoCrust and DeepPit
+        /// removals occur on the same day — each state type is a distinct tank.
         /// </summary>
         [TestMethod]
         public void GetTotalVolumeOfManureRemovedFromStorageOnDay_CountsOnlyMatchingSystemWhenBothPresent()
         {
-            // Arrange: a liquid application/export (80 kg) plus an additional solid application (20 kg) on the same day.
+            // Arrange: LiquidNoCrust removals (80 kg) plus a DeepPit application (20 kg) on the same day.
             var day = new DateTime(2025, 6, 1);
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.LiquidNoCrust);
 
-            var solidCrop = new CropViewItem { Area = 10 };
-            solidCrop.ManureApplicationViewItems.Add(new ManureApplicationViewItem
+            var deepPitCrop = new CropViewItem { Area = 10 };
+            deepPitCrop.ManureApplicationViewItems.Add(new ManureApplicationViewItem
             {
                 DateOfApplication = day,
-                AmountOfManureAppliedPerHectare = 2, // 2 kg ha^-1 x 10 ha = 20 kg solid
+                AmountOfManureAppliedPerHectare = 2, // 2 kg ha^-1 x 10 ha = 20 kg from DeepPit
                 AnimalType = AnimalType.DairyLactatingCow,
                 ManureLocationSourceType = ManureLocationSourceType.Livestock,
-                ManureStateType = ManureStateType.Solid,
+                ManureStateType = ManureStateType.DeepPit,
             });
-            var solidField = new FieldSystemComponent();
-            solidField.CropViewItems.Add(solidCrop);
-            farm.Components.Add(solidField);
+            var deepPitField = new FieldSystemComponent();
+            deepPitField.CropViewItems.Add(deepPitCrop);
+            farm.Components.Add(deepPitField);
 
-            // Act: query the liquid system.
+            // Act: query the LiquidNoCrust system.
             var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
 
-            // Assert: only the 80 kg of liquid removals count; the 20 kg solid application is excluded.
+            // Assert: only the 80 kg of LiquidNoCrust removals count; the 20 kg DeepPit application is excluded.
             Assert.AreEqual(80, result, 1e-9);
+        }
+
+        /// <summary>
+        /// A matching state type alone is not sufficient — the animal category must also match. A beef LiquidNoCrust
+        /// removal must not draw down the dairy LiquidNoCrust tank.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_SameStateType_WrongAnimalCategory_ReturnsZero()
+        {
+            // Arrange: all removals on this day are LiquidNoCrust but from beef animals.
+            var day = new DateTime(2025, 6, 1);
+            var farm = BuildFarmWithRemoval(day, AnimalType.BeefBackgrounder, ManureLocationSourceType.Livestock, ManureStateType.LiquidNoCrust);
+
+            // Act: query the dairy LiquidNoCrust system.
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
+
+            // Assert: state type matches but animal category doesn't, so nothing is counted.
+            Assert.AreEqual(0, result, 1e-9);
+        }
+
+        /// <summary>
+        /// Matching removals spread across multiple fields and crops on the same day are all accumulated into the total.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_MultipleFieldsSameStateType_SumsAll()
+        {
+            // Arrange: two separate fields both receive LiquidNoCrust dairy manure on the same day.
+            var day = new DateTime(2025, 6, 1);
+            var farm = base.GetTestFarm();
+            farm.Components.Clear();
+            farm.ManureExportViewItems.Clear();
+
+            // Field 1: 5 kg/ha x 10 ha = 50 kg
+            var crop1 = new CropViewItem { Area = 10 };
+            crop1.ManureApplicationViewItems.Add(new ManureApplicationViewItem
+            {
+                DateOfApplication = day,
+                AmountOfManureAppliedPerHectare = 5,
+                AnimalType = AnimalType.DairyLactatingCow,
+                ManureLocationSourceType = ManureLocationSourceType.Livestock,
+                ManureStateType = ManureStateType.LiquidNoCrust,
+            });
+            var field1 = new FieldSystemComponent();
+            field1.CropViewItems.Add(crop1);
+            farm.Components.Add(field1);
+
+            // Field 2: 3 kg/ha x 20 ha = 60 kg
+            var crop2 = new CropViewItem { Area = 20 };
+            crop2.ManureApplicationViewItems.Add(new ManureApplicationViewItem
+            {
+                DateOfApplication = day,
+                AmountOfManureAppliedPerHectare = 3,
+                AnimalType = AnimalType.DairyLactatingCow,
+                ManureLocationSourceType = ManureLocationSourceType.Livestock,
+                ManureStateType = ManureStateType.LiquidNoCrust,
+            });
+            var field2 = new FieldSystemComponent();
+            field2.CropViewItems.Add(crop2);
+            farm.Components.Add(field2);
+
+            // Act
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
+
+            // Assert: both field applications are summed.
+            Assert.AreEqual(110, result, 1e-9); // 50 + 60
+        }
+
+        /// <summary>
+        /// An export with a non-matching state type is excluded, even if the date and animal category match.
+        /// This verifies the state-type filter applies independently to the export path.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExportWithWrongStateType_Excluded()
+        {
+            // Arrange: a LiquidNoCrust land application (50 kg) and a DeepPit export (30 kg) on the same day.
+            var day = new DateTime(2025, 6, 1);
+            var farm = base.GetTestFarm();
+            farm.Components.Clear();
+            farm.ManureExportViewItems.Clear();
+
+            var crop = new CropViewItem { Area = 10 };
+            crop.ManureApplicationViewItems.Add(new ManureApplicationViewItem
+            {
+                DateOfApplication = day,
+                AmountOfManureAppliedPerHectare = 5, // 50 kg from LiquidNoCrust
+                AnimalType = AnimalType.DairyLactatingCow,
+                ManureLocationSourceType = ManureLocationSourceType.Livestock,
+                ManureStateType = ManureStateType.LiquidNoCrust,
+            });
+            var field = new FieldSystemComponent();
+            field.CropViewItems.Add(crop);
+            farm.Components.Add(field);
+
+            farm.ManureExportViewItems.Add(new ManureExportViewItem
+            {
+                DateOfExport = day,
+                Amount = 30, // 30 kg from a DeepPit tank
+                AnimalType = AnimalType.DairyLactatingCow,
+                ManureStateType = ManureStateType.DeepPit,
+            });
+
+            // Act: query only the LiquidNoCrust system.
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
+
+            // Assert: only the 50 kg LiquidNoCrust application counts; the DeepPit export is excluded.
+            Assert.AreEqual(50, result, 1e-9);
         }
 
         #endregion

--- a/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
+++ b/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
@@ -228,9 +228,8 @@ namespace H.Core.Test.Services.Animals
         /// When querying a LiquidNoCrust system, removals from a DeepPit tank are excluded because each state type
         /// represents a distinct storage tank (Eq. 4.1.3-6, issue #434).
         /// </summary>
-        [TestMethod]
-        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesSolidRemovalsWhenQueryingLiquidSystem()
-        {
+[TestMethod]
+public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesDeepPitRemovalsWhenQueryingLiquidNoCrust()
             // Arrange: all removals on this day are from a DeepPit tank.
             var day = new DateTime(2025, 6, 1);
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.DeepPit);

--- a/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
+++ b/H.Core.Test/Services/Animals/ManureRemovalVolatileSolidsTest.cs
@@ -140,8 +140,8 @@ namespace H.Core.Test.Services.Animals
 
         // Builds a farm with exactly one land application (5 kg/ha over a 10 ha field = 50 kg) and one 30 kg export,
         // both for the given animal type on the given day. The application's source (on-farm vs imported) is varied
-        // by the tests.
-        private Farm BuildFarmWithRemoval(DateTime day, AnimalType animalType, ManureLocationSourceType applicationSource)
+        // by the tests. Both removals use the given manure state type (defaults to a liquid system).
+        private Farm BuildFarmWithRemoval(DateTime day, AnimalType animalType, ManureLocationSourceType applicationSource, ManureStateType manureStateType = ManureStateType.LiquidNoCrust)
         {
             var farm = base.GetTestFarm();
             farm.Components.Clear();            // start from a known-empty farm so only our records count
@@ -154,6 +154,7 @@ namespace H.Core.Test.Services.Animals
                 AmountOfManureAppliedPerHectare = 5, // kg ha^-1 -> x 10 ha = 50 kg
                 AnimalType = animalType,
                 ManureLocationSourceType = applicationSource,
+                ManureStateType = manureStateType,
             });
 
             var field = new FieldSystemComponent();
@@ -165,6 +166,7 @@ namespace H.Core.Test.Services.Animals
                 DateOfExport = day,
                 Amount = 30,
                 AnimalType = animalType,
+                ManureStateType = manureStateType,
             });
 
             return farm;
@@ -181,7 +183,7 @@ namespace H.Core.Test.Services.Animals
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock);
 
             // Act: total manure that left storage that day for dairy.
-            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow);
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
 
             // Assert: both removal streams are summed.
             Assert.AreEqual(80, result, 1e-9); // 5 * 10 (applied) + 30 (exported)
@@ -199,7 +201,7 @@ namespace H.Core.Test.Services.Animals
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Imported);
 
             // Act
-            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow);
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
 
             // Assert: the imported application is skipped; only the 30 kg export counts.
             Assert.AreEqual(30, result, 1e-9);
@@ -216,10 +218,76 @@ namespace H.Core.Test.Services.Animals
             var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock);
 
             // Act: ...but we query the following day, which has none.
-            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day.AddDays(1), farm, AnimalType.DairyLactatingCow);
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day.AddDays(1), farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
 
             // Assert
             Assert.AreEqual(0, result, 1e-9);
+        }
+
+        /// <summary>
+        /// When querying a liquid system, solid manure removals are excluded because liquid and solid manure are held
+        /// in separate storage (Eq. 4.1.3-6, issue #434). A solid application must not draw down the liquid tank.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesSolidRemovalsWhenQueryingLiquidSystem()
+        {
+            // Arrange: all removals on this day are solid manure.
+            var day = new DateTime(2025, 6, 1);
+            var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.Solid);
+
+            // Act: query the liquid system for that day.
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
+
+            // Assert: no liquid removals occurred, so nothing is drawn down from the liquid tank.
+            Assert.AreEqual(0, result, 1e-9);
+        }
+
+        /// <summary>
+        /// When querying a solid system, liquid manure removals are excluded for the same separate-storage reason.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_ExcludesLiquidRemovalsWhenQueryingSolidSystem()
+        {
+            // Arrange: all removals on this day are liquid manure.
+            var day = new DateTime(2025, 6, 1);
+            var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.LiquidNoCrust);
+
+            // Act: query the solid system for that day.
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.Solid);
+
+            // Assert: no solid removals occurred.
+            Assert.AreEqual(0, result, 1e-9);
+        }
+
+        /// <summary>
+        /// Querying a liquid system counts only the liquid removals when both liquid and solid removals occur on the
+        /// same day for the same animal type.
+        /// </summary>
+        [TestMethod]
+        public void GetTotalVolumeOfManureRemovedFromStorageOnDay_CountsOnlyMatchingSystemWhenBothPresent()
+        {
+            // Arrange: a liquid application/export (80 kg) plus an additional solid application (20 kg) on the same day.
+            var day = new DateTime(2025, 6, 1);
+            var farm = BuildFarmWithRemoval(day, AnimalType.DairyLactatingCow, ManureLocationSourceType.Livestock, ManureStateType.LiquidNoCrust);
+
+            var solidCrop = new CropViewItem { Area = 10 };
+            solidCrop.ManureApplicationViewItems.Add(new ManureApplicationViewItem
+            {
+                DateOfApplication = day,
+                AmountOfManureAppliedPerHectare = 2, // 2 kg ha^-1 x 10 ha = 20 kg solid
+                AnimalType = AnimalType.DairyLactatingCow,
+                ManureLocationSourceType = ManureLocationSourceType.Livestock,
+                ManureStateType = ManureStateType.Solid,
+            });
+            var solidField = new FieldSystemComponent();
+            solidField.CropViewItems.Add(solidCrop);
+            farm.Components.Add(solidField);
+
+            // Act: query the liquid system.
+            var result = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(day, farm, AnimalType.DairyLactatingCow, ManureStateType.LiquidNoCrust);
+
+            // Assert: only the 80 kg of liquid removals count; the 20 kg solid application is excluded.
+            Assert.AreEqual(80, result, 1e-9);
         }
 
         #endregion

--- a/H.Core/Services/Animals/AnimalResultsServiceBase.cs
+++ b/H.Core/Services/Animals/AnimalResultsServiceBase.cs
@@ -901,6 +901,9 @@ namespace H.Core.Services.Animals
                 return 0;
             }
 
+            // The removed volume is scoped to the management system (liquid or solid) by
+            // GetTotalVolumeOfManureRemovedFromStorageOnDay, so solid manure applications do not reduce the volatile
+            // solids held in a separate liquid tank (Eq. 4.1.3-6, issue #434).
             var fraction = emissionsForDay.VolumeOfManureRemovedFromStorageOnDay / emissionsForDay.AccumulatedVolumeNetOfRemovals;
 
             return this.BoundRemovalFraction(fraction);
@@ -986,8 +989,10 @@ namespace H.Core.Services.Animals
                 fractionOfManureRemovedFromStorageOnPreviousDay: fractionRemovedOnPreviousDay);
 
             // Volume of manure removed from storage on the current day (read by the following day to form the fraction).
+            // Only removals from the same management system (liquid or solid) as this management period are counted, so a
+            // solid manure application does not reduce the volatile solids held in a separate liquid storage tank.
             todaysState.VolumeRemovedOnDay = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(
-                dailyEmissions.DateTime, farm, managementPeriod.AnimalType);
+                dailyEmissions.DateTime, farm, managementPeriod.AnimalType, managementPeriod.ManureDetails.StateType);
 
             WriteManureStorageState(dailyEmissions, todaysState);
         }

--- a/H.Core/Services/Animals/AnimalResultsServiceBase.cs
+++ b/H.Core/Services/Animals/AnimalResultsServiceBase.cs
@@ -989,8 +989,15 @@ namespace H.Core.Services.Animals
                 fractionOfManureRemovedFromStorageOnPreviousDay: fractionRemovedOnPreviousDay);
 
             // Volume of manure removed from storage on the current day (read by the following day to form the fraction).
-            // Only removals from the same management system (liquid or solid) as this management period are counted, so a
-            // solid manure application does not reduce the volatile solids held in a separate liquid storage tank.
+            // Only removals whose ManureStateType exactly matches this management period's state type are counted,
+            // since each state type represents a distinct physical storage tank (issue #434).
+            //
+            // KNOWN LIMITATION (see follow-on issue): the denominator (AccumulatedVolumeNetOfRemovals) is accumulated
+            // per management period, but the physical model has one shared tank per year/animal-category/state-type.
+            // If multiple management periods feed the same tank (e.g. lactating cows + heifers both using
+            // LiquidNoCrust), the denominator understates the true tank volume, causing the removal fraction to be
+            // overstated for each period. This should be corrected by tracking the accumulated volume at the tank
+            // level rather than the management-period level.
             todaysState.VolumeRemovedOnDay = _manureService.GetTotalVolumeOfManureRemovedFromStorageOnDay(
                 dailyEmissions.DateTime, farm, managementPeriod.AnimalType, managementPeriod.ManureDetails.StateType);
 

--- a/H.Core/Services/Animals/AnimalResultsServiceBase.cs
+++ b/H.Core/Services/Animals/AnimalResultsServiceBase.cs
@@ -901,9 +901,9 @@ namespace H.Core.Services.Animals
                 return 0;
             }
 
-            // The removed volume is scoped to the management system (liquid or solid) by
-            // GetTotalVolumeOfManureRemovedFromStorageOnDay, so solid manure applications do not reduce the volatile
-            // solids held in a separate liquid tank (Eq. 4.1.3-6, issue #434).
+// The removed volume is scoped to the exact manure state type by GetTotalVolumeOfManureRemovedFromStorageOnDay,
+// so removals from other storage tanks (including other liquid systems) do not reduce the volatile solids in this tank
+// (Eq. 4.1.3-6, issue #434).
             var fraction = emissionsForDay.VolumeOfManureRemovedFromStorageOnDay / emissionsForDay.AccumulatedVolumeNetOfRemovals;
 
             return this.BoundRemovalFraction(fraction);

--- a/H.Core/Services/Animals/AnimalResultsServiceBase.cs
+++ b/H.Core/Services/Animals/AnimalResultsServiceBase.cs
@@ -992,7 +992,7 @@ namespace H.Core.Services.Animals
             // Only removals whose ManureStateType exactly matches this management period's state type are counted,
             // since each state type represents a distinct physical storage tank (issue #434).
             //
-            // KNOWN LIMITATION (see follow-on issue): the denominator (AccumulatedVolumeNetOfRemovals) is accumulated
+            // KNOWN LIMITATION (see issue #451): the denominator (AccumulatedVolumeNetOfRemovals) is accumulated
             // per management period, but the physical model has one shared tank per year/animal-category/state-type.
             // If multiple management periods feed the same tank (e.g. lactating cows + heifers both using
             // LiquidNoCrust), the denominator understates the true tank volume, causing the removal fraction to be

--- a/H.Core/Services/Animals/IManureService.cs
+++ b/H.Core/Services/Animals/IManureService.cs
@@ -34,9 +34,10 @@ namespace H.Core.Services.Animals
 
         /// <summary>
         /// Returns the total volume of manure removed from storage on a given day for a given animal type and manure
-        /// management system, through on-farm land application and off-farm export. Only removals belonging to the same
-        /// management system (liquid or solid) as <paramref name="manureStateType"/> are counted, since liquid and solid
-        /// manure are held in separate storage. Imported manure applications are excluded.
+        /// management system, through on-farm land application and off-farm export. Only removals whose
+        /// <see cref="ManureItemBase.ManureStateType"/> exactly matches <paramref name="manureStateType"/> are counted,
+        /// since each state type represents a distinct storage tank (consistent with how tanks are keyed in
+        /// <see cref="IManureService.GetTank"/>). Imported manure applications are excluded.
         ///
         /// (kg)
         /// </summary>

--- a/H.Core/Services/Animals/IManureService.cs
+++ b/H.Core/Services/Animals/IManureService.cs
@@ -33,12 +33,14 @@ namespace H.Core.Services.Animals
         double GetTotalVolumeOfManureExported(int year, Farm farm, AnimalType animalType);
 
         /// <summary>
-        /// Returns the total volume of manure removed from storage on a given day for a given animal type, through
-        /// on-farm land application and off-farm export. Imported manure applications are excluded.
+        /// Returns the total volume of manure removed from storage on a given day for a given animal type and manure
+        /// management system, through on-farm land application and off-farm export. Only removals belonging to the same
+        /// management system (liquid or solid) as <paramref name="manureStateType"/> are counted, since liquid and solid
+        /// manure are held in separate storage. Imported manure applications are excluded.
         ///
         /// (kg)
         /// </summary>
-        double GetTotalVolumeOfManureRemovedFromStorageOnDay(DateTime dateTime, Farm farm, AnimalType animalType);
+        double GetTotalVolumeOfManureRemovedFromStorageOnDay(DateTime dateTime, Farm farm, AnimalType animalType, ManureStateType manureStateType);
         int GetYearHighestVolumeRemaining(AnimalType animalType);
         DefaultManureCompositionData GetManureCompositionData(Farm farm, ManureStateType manureStateType,
             AnimalType animalType);

--- a/H.Core/Services/Animals/ManureService.cs
+++ b/H.Core/Services/Animals/ManureService.cs
@@ -211,16 +211,16 @@ namespace H.Core.Services.Animals
         /// manure was never held in this farm's storage. The volume diverted to an anaerobic digester is added separately
         /// by the caller (it is computed from the digester flows).
         ///
-        /// Only removals belonging to the same management system (liquid or solid) as <paramref name="manureStateType"/>
-        /// are counted, because liquid and solid manure are held in separate storage. For example, a solid manure field
-        /// application must not draw down the volume held in a liquid storage tank.
+        /// Only removals whose <see cref="ManureItemBase.ManureStateType"/> exactly matches <paramref name="manureStateType"/>
+        /// are counted, because each state type represents a distinct storage tank (e.g. LiquidNoCrust and DeepPit are
+        /// separate tanks). This is consistent with how <see cref="GetManureTankInternal"/> keys tanks and how
+        /// <see cref="UpdateAmountsUsed"/> debits them — both use exact ManureStateType equality.
         ///
         /// (kg)
         /// </summary>
         public double GetTotalVolumeOfManureRemovedFromStorageOnDay(DateTime dateTime, Farm farm, AnimalType animalType, ManureStateType manureStateType)
         {
             var result = 0d;
-            var isLiquidSystem = manureStateType.IsLiquidManure();
 
             // Manure produced on this farm and applied to a field.
             foreach (var fieldSystemComponent in farm.FieldSystemComponents)
@@ -236,7 +236,7 @@ namespace H.Core.Services.Animals
 
                         if (manureApplicationViewItem.DateOfApplication.Date == dateTime.Date &&
                             manureApplicationViewItem.AnimalType.GetCategory() == animalType.GetCategory() &&
-                            manureApplicationViewItem.ManureStateType.IsLiquidManure() == isLiquidSystem)
+                            manureApplicationViewItem.ManureStateType == manureStateType)
                         {
                             result += manureApplicationViewItem.AmountOfManureAppliedPerHectare * cropViewItem.Area;
                         }
@@ -249,7 +249,7 @@ namespace H.Core.Services.Animals
             {
                 if (manureExportViewItem.DateOfExport.Date == dateTime.Date &&
                     manureExportViewItem.AnimalType.GetCategory() == animalType.GetCategory() &&
-                    manureExportViewItem.ManureStateType.IsLiquidManure() == isLiquidSystem)
+                    manureExportViewItem.ManureStateType == manureStateType)
                 {
                     result += manureExportViewItem.Amount;
                 }

--- a/H.Core/Services/Animals/ManureService.cs
+++ b/H.Core/Services/Animals/ManureService.cs
@@ -205,16 +205,22 @@ namespace H.Core.Services.Animals
         }
 
         /// <summary>
-        /// Returns the total volume of manure removed from storage on a given day for a given animal type. Manure is
-        /// removed from storage when manure produced on this farm is applied to a field or exported off-farm. Imported
-        /// manure applications are excluded because that manure was never held in this farm's storage. The volume
-        /// diverted to an anaerobic digester is added separately by the caller (it is computed from the digester flows).
+        /// Returns the total volume of manure removed from storage on a given day for a given animal type and manure
+        /// management system (Eq. 4.1.3-6, Volume_manureremoved). Manure is removed from storage when manure produced on
+        /// this farm is applied to a field or exported off-farm. Imported manure applications are excluded because that
+        /// manure was never held in this farm's storage. The volume diverted to an anaerobic digester is added separately
+        /// by the caller (it is computed from the digester flows).
+        ///
+        /// Only removals belonging to the same management system (liquid or solid) as <paramref name="manureStateType"/>
+        /// are counted, because liquid and solid manure are held in separate storage. For example, a solid manure field
+        /// application must not draw down the volume held in a liquid storage tank.
         ///
         /// (kg)
         /// </summary>
-        public double GetTotalVolumeOfManureRemovedFromStorageOnDay(DateTime dateTime, Farm farm, AnimalType animalType)
+        public double GetTotalVolumeOfManureRemovedFromStorageOnDay(DateTime dateTime, Farm farm, AnimalType animalType, ManureStateType manureStateType)
         {
             var result = 0d;
+            var isLiquidSystem = manureStateType.IsLiquidManure();
 
             // Manure produced on this farm and applied to a field.
             foreach (var fieldSystemComponent in farm.FieldSystemComponents)
@@ -229,7 +235,8 @@ namespace H.Core.Services.Animals
                         }
 
                         if (manureApplicationViewItem.DateOfApplication.Date == dateTime.Date &&
-                            manureApplicationViewItem.AnimalType.GetCategory() == animalType.GetCategory())
+                            manureApplicationViewItem.AnimalType.GetCategory() == animalType.GetCategory() &&
+                            manureApplicationViewItem.ManureStateType.IsLiquidManure() == isLiquidSystem)
                         {
                             result += manureApplicationViewItem.AmountOfManureAppliedPerHectare * cropViewItem.Area;
                         }
@@ -241,7 +248,8 @@ namespace H.Core.Services.Animals
             foreach (var manureExportViewItem in farm.ManureExportViewItems)
             {
                 if (manureExportViewItem.DateOfExport.Date == dateTime.Date &&
-                    manureExportViewItem.AnimalType.GetCategory() == animalType.GetCategory())
+                    manureExportViewItem.AnimalType.GetCategory() == animalType.GetCategory() &&
+                    manureExportViewItem.ManureStateType.IsLiquidManure() == isLiquidSystem)
                 {
                     result += manureExportViewItem.Amount;
                 }


### PR DESCRIPTION
## Summary

Fixes #434. When liquid manure is removed from storage, the VS adjustment (Eq. 4.1.3-6) was incorrectly including removals from other manure state types (e.g. a solid manure application reducing the VS in a liquid tank). Since each state type represents a distinct physical storage tank, only removals whose `ManureStateType` exactly matches the management period being advanced should count.

## Changes
- `ManureService.GetTotalVolumeOfManureRemovedFromStorageOnDay` — added `ManureStateType` parameter; both field applications and exports are now filtered by exact state type equality, consistent with how `GetManureTankInternal` keys tanks
- `IManureService` — updated interface signature and doc comment
- `AnimalResultsServiceBase.AdvanceManureStorageByOneDay` — passes `managementPeriod.ManureDetails.StateType` to the method above

## Tests
25 tests passing in `ManureRemovalVolatileSolidsTest`, including new cases for:
- DeepPit removals excluded when querying LiquidNoCrust (and vice versa)
- Same state type, wrong animal category → excluded
- Multiple fields with same state type → summed correctly
- Export with non-matching state type → excluded

## Known limitation
A related issue was identified during this work and tracked separately in #451: the denominator (`AccumulatedVolumeNetOfRemovals`) is accumulated per management period, but the physical model has one shared tank per year/animal-category/state-type. This will be addressed in a follow-on branch.