### PR TITLE
Add CoordinateParser for latitude/longitude entry (#340)

### DIFF
--- a/H.Infrastructure.Test/CoordinateParserTest.cs
+++ b/H.Infrastructure.Test/CoordinateParserTest.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using H.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace H.Infrastructure.Test
+{
+    /// <summary>
+    /// Edge-case coverage for <see cref="CoordinateParser"/> - the latitude/longitude parsing used by the "Enter
+    /// Coordinates" dialog (issue #340).
+    /// </summary>
+    [TestClass]
+    public class CoordinateParserTest
+    {
+        private const double Delta = 0.0000001;
+
+        #region Valid input
+
+        [TestMethod]
+        public void TryParseLatitude_ValidDecimal_ReturnsTrueWithValue()
+        {
+            var result = CoordinateParser.TryParseLatitude("52.30845", out var latitude);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(52.30845, latitude, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseLongitude_ValidNegativeDecimal_ReturnsTrueWithValue()
+        {
+            var result = CoordinateParser.TryParseLongitude("-112.51918", out var longitude);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(-112.51918, longitude, Delta);
+        }
+
+        /// <summary>
+        /// The exact example values shown in the dialog. This is the pair that previously failed validation, so it
+        /// guards against a regression of that bug.
+        /// </summary>
+        [TestMethod]
+        public void TryParse_DialogExampleValues_Succeed()
+        {
+            Assert.IsTrue(CoordinateParser.TryParseLatitude("52.30845", out var latitude));
+            Assert.IsTrue(CoordinateParser.TryParseLongitude("-112.51918", out var longitude));
+            Assert.AreEqual(52.30845, latitude, Delta);
+            Assert.AreEqual(-112.51918, longitude, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_LeadingPlusSign_ReturnsTrue()
+        {
+            var result = CoordinateParser.TryParseCoordinate("+52.3", out var value);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(52.3, value, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_SurroundingWhitespace_IsTrimmed()
+        {
+            var result = CoordinateParser.TryParseCoordinate("   52.3   ", out var value);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(52.3, value, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_Integer_ReturnsTrue()
+        {
+            var result = CoordinateParser.TryParseCoordinate("52", out var value);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(52.0, value, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_Zero_ReturnsTrue()
+        {
+            var result = CoordinateParser.TryParseCoordinate("0", out var value);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(0.0, value, Delta);
+        }
+
+        #endregion
+
+        #region Malformed input
+
+        [TestMethod]
+        public void TryParseCoordinate_Null_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate(null, out var value));
+            Assert.AreEqual(0.0, value, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_EmptyString_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate(string.Empty, out _));
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_WhitespaceOnly_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate("     ", out _));
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_NonNumericText_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate("north", out _));
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_MultipleDecimalPoints_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate("52.30.845", out _));
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_ExponentNotation_ReturnsFalse()
+        {
+            // Coordinates are plain decimals; scientific notation is intentionally rejected.
+            Assert.IsFalse(CoordinateParser.TryParseCoordinate("5e1", out _));
+        }
+
+        [TestMethod]
+        public void TryParseCoordinate_ThousandsSeparator_ReturnsFalse()
+        {
+            // A comma is a decimal separator in some locales, so pin the culture to one where it would be a thousands
+            // separator and confirm it is rejected (thousands separators are not permitted).
+            RunInCulture("en-US", () =>
+                Assert.IsFalse(CoordinateParser.TryParseCoordinate("1,234", out _)));
+        }
+
+        #endregion
+
+        #region Range validation
+
+        [TestMethod]
+        public void TryParseLatitude_AboveMaximum_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseLatitude("90.1", out _));
+        }
+
+        [TestMethod]
+        public void TryParseLatitude_BelowMinimum_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseLatitude("-90.1", out _));
+        }
+
+        [TestMethod]
+        public void TryParseLatitude_Boundaries_ReturnTrue()
+        {
+            Assert.IsTrue(CoordinateParser.TryParseLatitude("90", out var high));
+            Assert.IsTrue(CoordinateParser.TryParseLatitude("-90", out var low));
+            Assert.AreEqual(90.0, high, Delta);
+            Assert.AreEqual(-90.0, low, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseLongitude_AboveMaximum_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseLongitude("180.1", out _));
+        }
+
+        [TestMethod]
+        public void TryParseLongitude_BelowMinimum_ReturnsFalse()
+        {
+            Assert.IsFalse(CoordinateParser.TryParseLongitude("-180.1", out _));
+        }
+
+        [TestMethod]
+        public void TryParseLongitude_Boundaries_ReturnTrue()
+        {
+            Assert.IsTrue(CoordinateParser.TryParseLongitude("180", out var high));
+            Assert.IsTrue(CoordinateParser.TryParseLongitude("-180", out var low));
+            Assert.AreEqual(180.0, high, Delta);
+            Assert.AreEqual(-180.0, low, Delta);
+        }
+
+        [TestMethod]
+        public void TryParseLatitude_ValueValidOnlyAsLongitude_ReturnsFalse()
+        {
+            // 150 is a valid longitude but out of range for a latitude.
+            Assert.IsFalse(CoordinateParser.TryParseLatitude("150", out _));
+            Assert.IsTrue(CoordinateParser.TryParseLongitude("150", out _));
+        }
+
+        [TestMethod]
+        public void TryParseLatitude_OutOfRange_ResetsOutValueToZero()
+        {
+            CoordinateParser.TryParseLatitude("500", out var value);
+            Assert.AreEqual(0.0, value, Delta);
+        }
+
+        #endregion
+
+        #region Culture handling
+
+        [TestMethod]
+        public void TryParseLatitude_DotDecimalUnderCommaCulture_StillParses()
+        {
+            // GPS values use a dot separator regardless of locale; the invariant culture is tried first.
+            RunInCulture("fr-CA", () =>
+            {
+                Assert.IsTrue(CoordinateParser.TryParseLatitude("52.30845", out var latitude));
+                Assert.AreEqual(52.30845, latitude, Delta);
+            });
+        }
+
+        [TestMethod]
+        public void TryParseLatitude_CommaDecimalUnderCommaCulture_Parses()
+        {
+            RunInCulture("fr-CA", () =>
+            {
+                Assert.IsTrue(CoordinateParser.TryParseLatitude("52,30845", out var latitude));
+                Assert.AreEqual(52.30845, latitude, Delta);
+            });
+        }
+
+        [TestMethod]
+        public void TryParseLongitude_CommaDecimalNegativeUnderCommaCulture_Parses()
+        {
+            RunInCulture("fr-CA", () =>
+            {
+                Assert.IsTrue(CoordinateParser.TryParseLongitude("-112,51918", out var longitude));
+                Assert.AreEqual(-112.51918, longitude, Delta);
+            });
+        }
+
+        #endregion
+
+        private static void RunInCulture(string cultureName, Action action)
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+                action();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+    }
+}

--- a/H.Infrastructure.Test/H.Infrastructure.Test.csproj
+++ b/H.Infrastructure.Test/H.Infrastructure.Test.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CoordinateParserTest.cs" />
     <Compile Include="KmlHelpersTest.cs" />
     <Compile Include="ListExtensionsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/H.Infrastructure/CoordinateParser.cs
+++ b/H.Infrastructure/CoordinateParser.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+
+namespace H.Infrastructure
+{
+    /// <summary>
+    /// Parses latitude/longitude values typed by the user (issue #340). GPS coordinates are conventionally written with
+    /// a dot decimal separator regardless of locale, so the invariant culture is tried first and the user's current
+    /// culture (for example a comma-decimal locale such as fr-CA) is accepted as a fallback. Values are validated
+    /// against the geographic range for a latitude or longitude.
+    /// </summary>
+    public static class CoordinateParser
+    {
+        public const double MinimumLatitude = -90.0;
+        public const double MaximumLatitude = 90.0;
+        public const double MinimumLongitude = -180.0;
+        public const double MaximumLongitude = 180.0;
+
+        /// <summary>
+        /// Attempts to parse a latitude. Returns <c>true</c> only when the text is a number within [-90, 90].
+        /// </summary>
+        public static bool TryParseLatitude(string text, out double latitude)
+        {
+            return TryParseInRange(text, MinimumLatitude, MaximumLatitude, out latitude);
+        }
+
+        /// <summary>
+        /// Attempts to parse a longitude. Returns <c>true</c> only when the text is a number within [-180, 180].
+        /// </summary>
+        public static bool TryParseLongitude(string text, out double longitude)
+        {
+            return TryParseInRange(text, MinimumLongitude, MaximumLongitude, out longitude);
+        }
+
+        /// <summary>
+        /// Attempts to parse a coordinate as a number, without range validation. Leading/trailing whitespace is
+        /// ignored, thousands separators are not permitted, and both the invariant and current cultures are accepted.
+        /// </summary>
+        public static bool TryParseCoordinate(string text, out double value)
+        {
+            value = 0.0;
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            text = text.Trim();
+
+            const NumberStyles numberStyles = NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint;
+
+            return double.TryParse(text, numberStyles, CultureInfo.InvariantCulture, out value) ||
+                   double.TryParse(text, numberStyles, CultureInfo.CurrentCulture, out value);
+        }
+
+        private static bool TryParseInRange(string text, double minimum, double maximum, out double value)
+        {
+            if (TryParseCoordinate(text, out value) && value >= minimum && value <= maximum)
+            {
+                return true;
+            }
+
+            value = 0.0;
+            return false;
+        }
+    }
+}

--- a/H.Infrastructure/H.Infrastructure.csproj
+++ b/H.Infrastructure/H.Infrastructure.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Csv.cs" />
     <Compile Include="CsvReader.cs" />
     <Compile Include="EnumHelper.cs" />
+    <Compile Include="CoordinateParser.cs" />
     <Compile Include="KmlHelpers.cs" />
     <Compile Include="MathHelpers.cs" />
     <Compile Include="MessageBase.cs" />


### PR DESCRIPTION
Adds `CoordinateParser` (issue #340) — the text→number logic for typing a latitude/longitude directly, used by the upcoming GPS coordinate-entry dialog in the GUI.

## What it does

A small stateless utility in `H.Infrastructure`:
- `TryParseLatitude` / `TryParseLongitude` — parse a number and validate it against the geographic range (`[-90, 90]` / `[-180, 180]`).
- `TryParseCoordinate` — the core parse: trims whitespace, allows a leading sign and decimal point, rejects thousands separators and exponent notation.

GPS coordinates are conventionally dot-decimal regardless of locale, so it tries the **invariant culture first**, then falls back to the user's **current culture** — so a comma-decimal locale (e.g. `fr-CA`) still works.

## Testing

25 unit tests in `H.Infrastructure.Test/CoordinateParserTest.cs` cover valid/negative/integer/zero parsing, latitude & longitude boundaries and out-of-range rejection, whitespace trimming, null/empty/non-numeric/multi-decimal/exponent/thousands-separator rejection, and culture-invariant parsing under a comma-decimal culture. All green.

Standalone utility — nothing on `main` references it yet; the GUI consumer (private repo) lands separately. Relates to #340.
