### PR TITLE
Match a hay import to its year by the date the user set

### DIFF
--- a/H.Core.Test/Calculators/Carbon/CarbonServiceTest.cs
+++ b/H.Core.Test/Calculators/Carbon/CarbonServiceTest.cs
@@ -170,6 +170,92 @@ namespace H.Core.Test.Calculators.Carbon
             Assert.AreEqual(850, result);
         }
 
+        /// <summary>
+        /// The real-world shape of a hay import: the user sets Date, and nothing ever assigns Start. The netting used
+        /// to filter on Start, which therefore sat at DateTime.MinValue and matched no simulation year, so hay fed back
+        /// onto the field it was cut from was still counted as having left the farm.
+        /// </summary>
+        [TestMethod]
+        public void CalculateTotalDryMatterLossFromResidueExportsNetsImportThatHasNoStartDateAssigned()
+        {
+            var farm = BuildFarmWithHayCut(out var field, out var exportingCropViewItem);
+            var withoutImport = _sut.CalculateTotalDryMatterLossFromResidueExports(exportingCropViewItem, farm);
+
+            var hayImportViewItem = new HayImportViewItem
+            {
+                FieldSourceGuid = field.Guid,
+                BaleWeight = 100,
+                NumberOfBales = 10,
+                MoistureContentAsPercentage = 50,
+                Date = new DateTime(exportingCropViewItem.Year, 10, 30),
+            };
+
+            Assert.AreEqual(1, hayImportViewItem.Start.Year, "this test is only meaningful while Start is left unassigned");
+
+            exportingCropViewItem.HayImportViewItems.Add(hayImportViewItem);
+
+            var withImport = _sut.CalculateTotalDryMatterLossFromResidueExports(exportingCropViewItem, farm);
+
+            Assert.IsTrue(withImport < withoutImport,
+                $"hay fed back onto its own field must reduce what is counted as exported ({withImport} vs {withoutImport})");
+        }
+
+        /// <summary>
+        /// The import's own date decides which year it is netted against. Repeating management is already expanded
+        /// into one copy per year before this runs, so matching on the repeat flag as well would count every year's
+        /// copy against every year.
+        /// </summary>
+        [TestMethod]
+        public void CalculateTotalDryMatterLossFromResidueExportsIgnoresImportFromAnotherYear()
+        {
+            var farm = BuildFarmWithHayCut(out var field, out var exportingCropViewItem);
+            var withoutImport = _sut.CalculateTotalDryMatterLossFromResidueExports(exportingCropViewItem, farm);
+
+            var hayImportViewItem = new HayImportViewItem
+            {
+                FieldSourceGuid = field.Guid,
+                BaleWeight = 100,
+                NumberOfBales = 10,
+                MoistureContentAsPercentage = 50,
+                Date = new DateTime(exportingCropViewItem.Year - 3, 10, 30),
+            };
+
+            exportingCropViewItem.HayImportViewItems.Add(hayImportViewItem);
+
+            Assert.AreEqual(withoutImport, _sut.CalculateTotalDryMatterLossFromResidueExports(exportingCropViewItem, farm));
+
+            // ... and is netted once it is dated to the year being calculated.
+            hayImportViewItem.Date = new DateTime(exportingCropViewItem.Year, 10, 30);
+
+            Assert.IsTrue(_sut.CalculateTotalDryMatterLossFromResidueExports(exportingCropViewItem, farm) < withoutImport);
+        }
+
+        private static Farm BuildFarmWithHayCut(out FieldSystemComponent field, out CropViewItem exportingCropViewItem)
+        {
+            field = new FieldSystemComponent { Guid = Guid.NewGuid() };
+
+            exportingCropViewItem = new CropViewItem
+            {
+                FieldSystemComponentGuid = field.Guid,
+                Year = DateTime.Now.Year,
+            };
+
+            exportingCropViewItem.HarvestViewItems.Add(new HarvestViewItem
+            {
+                Start = new DateTime(exportingCropViewItem.Year, 8, 3),
+                TotalNumberOfBalesHarvested = 20,
+                MoistureContentAsPercentage = 50,
+                BaleWeight = 100,
+            });
+
+            field.CropViewItems.Add(exportingCropViewItem);
+
+            var farm = new Farm();
+            farm.Components.Add(field);
+
+            return farm;
+        }
+
         #endregion
     }
 }

--- a/H.Core/Models/Farm.cs
+++ b/H.Core/Models/Farm.cs
@@ -1424,14 +1424,34 @@ namespace H.Core.Models
         public List<HayImportViewItem> GetHayImportsUsingImportedHayFromSourceFieldByYear(Guid fieldSystemGuid, int year)
         {
             var field = this.GetFieldSystemComponent(fieldSystemGuid);
-            if (field != null)
-            {
-                return this.GetHayImportsUsingImportedHayFromSourceField(field).Where(x => x.Start.Year.Equals(year)).ToList(); ;
-            }
-            else
+            if (field == null)
             {
                 return new List<HayImportViewItem>();
             }
+
+            return this.GetHayImportsUsingImportedHayFromSourceField(field)
+                       .Where(hayImport => HayImportBelongsToYear(hayImport, year))
+                       .ToList();
+        }
+
+        /// <summary>
+        /// Which year a hay import belongs to.
+        ///
+        /// This used to read <see cref="TimePeriodBase.Start"/>, which nothing ever assigns on a hay import - the date
+        /// the user sets is <see cref="HayImportViewItem.Date"/>, and that is also what the copy loop stamps when it
+        /// builds the per-year view items. Start was therefore left at DateTime.MinValue, no import matched any
+        /// simulation year, and bales fed back onto the field they were cut from were still counted as having left it.
+        /// On a field that is both hayed and grazed that removed the same carbon twice and could drive the carbon
+        /// returned to soil to zero.
+        ///
+        /// The date alone decides. Repeating management is already expanded into one copy per year by the time this
+        /// runs, each carrying its own date, so also matching on <see cref="IRepeatableFieldActivity.RepeatsInEveryYear"/>
+        /// would count every year's copy against every year - on a farm with an eight year simulation that netted
+        /// roughly eight times the hay that was actually fed.
+        /// </summary>
+        private static bool HayImportBelongsToYear(HayImportViewItem hayImport, int year)
+        {
+            return hayImport.Date.Year == year;
         }
 
         #endregion


### PR DESCRIPTION
Found while investigating a user farm where a hayed-and-grazed field reported 0% of product returned to soil in every year, with the "cut exceeds what the yield accounts for" message raised alongside it. Their data turned out to be correct; Holos was counting the same carbon twice.

## The defect

Hay cut from a field and fed back onto it never left the farm, so `CalculateTotalDryMatterLossFromResidueExports` nets it off what that field is counted as exporting:

```csharp
result = dryMatterHarvested - dryMatterImported;
```

The imports were fetched by year:

```csharp
.Where(x => x.Start.Year.Equals(year))
```

`Start` is inherited from `TimePeriodBase` and **nothing ever assigns it on a hay import**. The date the user sets is `HayImportViewItem.Date` ("the date the hay was added to the field"), and `Date` is also what the copy loop stamps when it builds the per-year view items:

```csharp
copiedHayImportViewItem.Date = new DateTime(year, copiedHayImportViewItem.DateCreated.Month, copiedHayImportViewItem.DateCreated.Day);
```

So `Start.Year` sat at 1, matched no simulation year, and the netting never fired. Every bale fed back onto its own field was still counted as having left it.

On a field that is both hayed and grazed, the grazing share and the full un-netted hay export are both subtracted from the same plant carbon, so the same carbon is removed twice. That can push the balance negative, which floors the carbon returned to soil at zero and raises the contradiction message.

## The fix

Match on `Date`. The date alone decides — see below.

## A wrong turn worth recording

The first attempt matched on `RepeatsInEveryYear || Date.Year == year`, reasoning that it should mirror the copy loop's rule. That is wrong, and instrumenting the user's farm showed why: by the time this runs, repeating management has **already** been expanded into one copy per year. The field had 8 component crop view items each holding 2 imports, and the repeat clause matched all 16 against every year - 1,707,059 kg of dry matter netted instead of 213,382, roughly eight times too much. It swamped the harvest, drove the export to zero and product-returned to 99%.

The comment in `HayImportBelongsToYear` records both halves of this so the flag is not re-added.

## Effect on the reporting user's farm

| | before | after |
|---|---|---|
| Bale export carbon | 234,335 kg C | 138,313 |
| Product returned to soil | 0% | 40.45% |
| Cut-exceeds-yield message | raised every year | gone |

Real farms are affected wherever hay is cut from a field and fed back on-farm with the source field recorded. Farms with no on-farm hay imports are unaffected.

## Testing

`H.Core` green at 1357 passed / 0 failed. No baseline moved - no fixture farm has an on-farm hay import, which is why this was never caught.

Two tests added. Note the two pre-existing tests for this method set `hayImportViewItem.Start` explicitly, which no production path does; that is exactly what masked the defect. The new tests leave `Start` unassigned as the interface does, and pin that the import's own date decides its year.

## Not addressed here

The same farm shows a second, separate problem: it is cut in August and grazed from late October, so the animals are on regrowth and stubble rather than competing with the hay for one standing crop. `HarvestMethods.StubbleGrazing` models that correctly but is commented out of the interface's `ValidHarvestMethods`. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)