### PR TITLE
Settle the roots-returned percentage before the carbon that uses it

### DIFF
--- a/H.Core.Test/Services/Animals/Baselines/Farm3.perennial-yields.baseline.txt
+++ b/H.Core.Test/Services/Animals/Baselines/Farm3.perennial-yields.baseline.txt
@@ -991,10 +991,10 @@ field=Field #4 | year=2024 | crop=TameGrass | PlantCarbonInAgriculturalProduct =
 field=Field #4 | year=2024 | crop=TameGrass | TotalCarbonInputs = 4315.4164
 field=Field #4 | year=2024 | crop=TameGrass | Yield = 25868.8000
 field=Field #4 | year=2025 | crop=TameGrass | AboveGroundCarbonInput = 9642.6072
-field=Field #4 | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 14778.4875
+field=Field #4 | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 12851.6954
 field=Field #4 | year=2025 | crop=TameGrass | PercentageOfProductYieldReturnedToSoil = 40.0000
 field=Field #4 | year=2025 | crop=TameGrass | PlantCarbonInAgriculturalProduct = 24106.5179
-field=Field #4 | year=2025 | crop=TameGrass | TotalCarbonInputs = 32925.2653
+field=Field #4 | year=2025 | crop=TameGrass | TotalCarbonInputs = 30998.4731
 field=Field #4 | year=2025 | crop=TameGrass | Yield = 267850.1990
 field=Field #5 | year=1985 | crop=RangelandNative | AboveGroundCarbonInput = 1764.7615
 field=Field #5 | year=1985 | crop=RangelandNative | BelowGroundCarbonInput = 3343.9580

--- a/H.Core.Test/Services/Animals/Baselines/Farm4.perennial-yields.baseline.txt
+++ b/H.Core.Test/Services/Animals/Baselines/Farm4.perennial-yields.baseline.txt
@@ -991,10 +991,10 @@ field=Field #4 | year=2024 | crop=TameGrass | PlantCarbonInAgriculturalProduct =
 field=Field #4 | year=2024 | crop=TameGrass | TotalCarbonInputs = 606.9366
 field=Field #4 | year=2024 | crop=TameGrass | Yield = 2833.3333
 field=Field #4 | year=2025 | crop=TameGrass | AboveGroundCarbonInput = 9779.9149
-field=Field #4 | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 13134.7024
+field=Field #4 | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 12495.5562
 field=Field #4 | year=2025 | crop=TameGrass | PercentageOfProductYieldReturnedToSoil = 39.9199
 field=Field #4 | year=2025 | crop=TameGrass | PlantCarbonInAgriculturalProduct = 24498.8256
-field=Field #4 | year=2025 | crop=TameGrass | TotalCarbonInputs = 31009.2153
+field=Field #4 | year=2025 | crop=TameGrass | TotalCarbonInputs = 30370.0690
 field=Field #4 | year=2025 | crop=TameGrass | Yield = 272209.1733
 field=Field #5 | year=1985 | crop=RangelandNative | AboveGroundCarbonInput = 1513.3230
 field=Field #5 | year=1985 | crop=RangelandNative | BelowGroundCarbonInput = 2867.5198
@@ -1489,8 +1489,8 @@ field=Hayed perennial | year=2024 | crop=TameGrass | PlantCarbonInAgriculturalPr
 field=Hayed perennial | year=2024 | crop=TameGrass | TotalCarbonInputs = 904.0247
 field=Hayed perennial | year=2024 | crop=TameGrass | Yield = 4958.3333
 field=Hayed perennial | year=2025 | crop=TameGrass | AboveGroundCarbonInput = 240.2885
-field=Hayed perennial | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 1413.3089
+field=Hayed perennial | year=2025 | crop=TameGrass | BelowGroundCarbonInput = 663.7363
 field=Hayed perennial | year=2025 | crop=TameGrass | PercentageOfProductYieldReturnedToSoil = 35.0000
 field=Hayed perennial | year=2025 | crop=TameGrass | PlantCarbonInAgriculturalProduct = 686.5385
-field=Hayed perennial | year=2025 | crop=TameGrass | TotalCarbonInputs = 4111.0328
+field=Hayed perennial | year=2025 | crop=TameGrass | TotalCarbonInputs = 3361.4602
 field=Hayed perennial | year=2025 | crop=TameGrass | Yield = 4958.3333

--- a/H.Core/Services/Initialization/Crops/CropInitializationService.Perennials.cs
+++ b/H.Core/Services/Initialization/Crops/CropInitializationService.Perennials.cs
@@ -33,17 +33,23 @@ namespace H.Core.Services.Initialization.Crops
         }
 
         /// <summary>
+        /// The share of a perennial's root biomass turned over, and so returned to the soil, in a year the stand
+        /// continues. The algorithm document gives Sr as 30% in every year but the termination year.
+        /// </summary>
+        private const double AnnualRootTurnoverPercentage = 30;
+
+        /// <summary>
         /// It is assumed that 30% of the root biomass is turned over (input) annually before harvest, and 100% on harvest for perennials
         /// </summary>
         public void AssignPerennialRootsReturned(IEnumerable<CropViewItem> list)
         {
-            var perennialStands = list.Where(x => x.CropType.IsPerennial()).GroupBy(x => x.PerennialStandGroupId);
+            var viewItemsForField = list.ToList();
+
+            var perennialStands = viewItemsForField.Where(x => x.CropType.IsPerennial()).GroupBy(x => x.PerennialStandGroupId);
             foreach (var currentPerennialStand in perennialStands)
             {
-                for (var index = 0; index < currentPerennialStand.OrderBy(x => x.Year).Count(); index++)
+                foreach (var cropViewItem in currentPerennialStand)
                 {
-                    var cropViewItem = currentPerennialStand.ElementAt(index);
-
                     // If the user has manually overridden the residue return values, skip this crop and preserve their custom values.
                     // This allows users to specify their own percentages for product, straw, roots, and extraroots returned to soil
                     // instead of using the default calculations. The user can set this override via the "Override residue return values"
@@ -53,26 +59,40 @@ namespace H.Core.Services.Initialization.Crops
                         continue;
                     }
 
-                    if (cropViewItem.YearInPerennialStand == cropViewItem.PerennialStandLength)
-                    {
-                        if (cropViewItem.CropType == CropType.RangelandNative)
-                        {
-                            // Range lands are never harvested and so we continue with 30% root turnover
-                            cropViewItem.PercentageOfRootsReturnedToSoil = 30;
-                        }
-                        else
-                        {
-                            // Last year of stand is when 100% of roots are returned
-                            cropViewItem.PercentageOfRootsReturnedToSoil = 100;
-                        }
-                    }
-                    else
-                    {
-                        // In years leading up to the last, only 30% of roots are returned
-                        cropViewItem.PercentageOfRootsReturnedToSoil = 30;
-                    }
+                    cropViewItem.PercentageOfRootsReturnedToSoil = IsStandTerminated(cropViewItem, viewItemsForField)
+                        ? 100
+                        : AnnualRootTurnoverPercentage;
                 }
             }
+        }
+
+        /// <summary>
+        /// The whole root mass is returned only when the stand is actually ploughed under and a different crop follows
+        /// it. Every other year - and every year of a stand that is never terminated - keeps the annual turnover.
+        ///
+        /// The "a different crop follows it" half of that used to be decided in
+        /// <see cref="H.Core.Services.LandManagement.FieldResultsService.PostProcessPerennials"/>, which runs after the
+        /// carbon inputs derived from this percentage have already been calculated, so the correction never reached
+        /// them: a stand running to the end of the simulation had its root carbon worked out at 100% while the details
+        /// screen displayed 30%. Deciding it here settles the value before anything reads it.
+        /// </summary>
+        private static bool IsStandTerminated(CropViewItem cropViewItem, List<CropViewItem> viewItemsForField)
+        {
+            if (cropViewItem.IsFinalYearInPerennialStand() == false)
+            {
+                return false;
+            }
+
+            // Range lands are never harvested and so continue with the annual root turnover
+            if (cropViewItem.CropType == CropType.RangelandNative)
+            {
+                return false;
+            }
+
+            // A stand that lasts to the end of the simulation is not ploughed under either. The algorithm document
+            // states this directly: a continuous perennial crop lasting until the end of the simulation period returns
+            // the annual turnover each year, "incl. the final year of the simulation".
+            return viewItemsForField.Any(x => x.Year == cropViewItem.Year + 1 && x.IsSecondaryCrop == false);
         }
 
         public void AssignPerennialViewItemsDescription(IEnumerable<CropViewItem> viewItems)

--- a/H.Core/Services/LandManagement/FieldResultsService.Perennials.cs
+++ b/H.Core/Services/LandManagement/FieldResultsService.Perennials.cs
@@ -31,17 +31,11 @@ namespace H.Core.Services.LandManagement
 
             foreach (var cropViewItem in viewItemsForField)
             {
-                var nextYear = cropViewItem.Year + 1;
-                var hasCropInNextYear = viewItemsForField.SingleOrDefault(x => x.Year == nextYear && x.IsSecondaryCrop == false) != null;
-
-                if (cropViewItem.CropType.IsPerennial() && cropViewItem.IsFinalYearInPerennialStand() && hasCropInNextYear == false && cropViewItem.OverrideResidueReturnedToSoilDefaults == false)
-                {
-                    cropViewItem.PercentageOfRootsReturnedToSoil = 30;
-                }
-                else
-                {
-                    // Leave whatever was set for the last year (by default this will be 100% set at initialization)
-                }
+                // The percentage of roots returned is NOT adjusted here. It used to be - a stand whose final year had
+                // no crop after it was put back to the annual turnover at this point - but this method runs after
+                // AssignCarbonInputs, which has already derived the root carbon from that percentage, so the change
+                // never reached the number it was meant to correct. It is decided in
+                // CropInitializationService.AssignPerennialRootsReturned instead, which runs before anything reads it.
 
                 if (farm.IsNonSwathingGrazingScenario(cropViewItem))
                 {


### PR DESCRIPTION
Closes #464.

## The defect

`FieldResultsService.PostProcessPerennials` put the roots-returned percentage back to the annual turnover for a stand whose final year has no crop after it:

```csharp
if (cropViewItem.CropType.IsPerennial() && cropViewItem.IsFinalYearInPerennialStand() &&
    hasCropInNextYear == false && cropViewItem.OverrideResidueReturnedToSoilDefaults == false)
{
    cropViewItem.PercentageOfRootsReturnedToSoil = 30;
}
```

But it runs **after** the carbon inputs derived from that percentage have been calculated. In `CreateDetailViewItemsForFarm`:

```csharp
this.CreateDetailViewItems(component, farm);   // ... -> AssignCarbonInputs(), which reads the percentage
...
this.PostProcessPerennials(component, farm);   // ... which then writes it
```

Nothing recalculates afterwards in GUI mode - `CalculateFinalResults` only re-derives inputs under `IsCommandLineMode`. So the correction never reached the number it was meant to correct: a non-rangeland stand running to the end of the simulation had its root carbon worked out at 100% while the Details screen displayed 30%.

That contradicts the algorithm document, which states a native rangeland or a continuous perennial lasting to the end of the simulation period returns the annual turnover each year, "incl. the final year of the simulation".

## The change

The decision moves into `CropInitializationService.AssignPerennialRootsReturned`, which runs from `ProcessPerennials` at the top of `CreateDetailViewItems` - before anything reads the value. It already receives the stand's full set of view items, so it can answer "is there a crop after the final year" itself without reaching for the stage state.

The three conditions now sit together in one predicate: it is the final year of the stand, the crop is not native rangeland, and a crop follows it. Rangeland was already handled there and is unchanged.

`PostProcessPerennials` keeps its other work (moisture content) and carries a comment saying why the percentage is deliberately not touched there.

## Results

Six baseline lines move, all in the fixtures' final simulation year, all on stands with no crop after them - exactly the case being corrected.

The clearest read is Farm4's "Hayed perennial": its below-ground carbon input sat at 663.7363 from 1989 through 2024 and jumped to 1413.3089 in 2025. It now stays at **663.7363**, continuous with every preceding year, which is what a stand that is never ploughed under should do.

Real farms are affected wherever a perennial stand runs to the end of the simulation without a crop following it. Stands that are genuinely terminated are unaffected, as is rangeland.

Note this partly offsets #463 on those fixtures, and correctly so: #463 changed what a terminating final year does, and this decides which stands are terminating in the first place. Before it, Sr was still 100 at the moment the root carbon was computed.

## Testing

`H.Core` green at 1356 passed / 0 failed / 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)