### PR TITLE
Document feeding your own hay back, and how perennial roots are returned

### DIFF
--- a/H.Content/Documentation/User Guide/User Guide.md
+++ b/H.Content/Documentation/User Guide/User Guide.md
@@ -2403,6 +2403,25 @@ Both paths follow the screens in order: everything about the field, the animals 
 -	Nothing removes product from the field, so 100% of it is returned to the soil. Holos sets this for you; earlier versions asked you to change it by hand.
 -	This depends on nothing being taken off the field, not on the yield being zero. A yield of zero usually means Holos had no yield to assign for that year — no Small Area Data for the crop and location, a Custom field you have not filled in, or an input file with no row for it — rather than that nothing grew, so it is not treated as evidence that the field was left uncut.
 
+### If you feed your own hay back to animals on the farm
+
+Hay that is cut from a field and then fed to animals somewhere on the same farm has not left the farm. Holos does not count it as exported, so the carbon in those bales is not treated as leaving the field it was cut from.
+
+-	This only happens if you tell Holos where the bales came from. In the **Add Supplemental Hay/Forage for Grazing Animals** table, set **Source of bales** to **On-farm**, then choose the field the hay was cut from in the **Field** column beside it. Leave the source as **Off-farm** and Holos treats the bales as bought in, so hay cut from your own field is still counted as having left it.
+-	Only the amount fed is deducted. If you cut 1,000 bales and feed 400 of them back, the remaining 600 count as leaving the field.
+-	This matters most on a field that is both cut and grazed. There, the forage the animals ate and the hay carted off are both taken away from the same crop, so hay wrongly counted as exported is removed twice — which can leave nothing credited as returned to soil and produce the message that the cut exceeds what the yield accounts for.
+-	The **Supplemental feeding loss (%)** setting in **User Settings** (default 20%) is separate. It is the share of the hay fed that the animals waste, which is returned to the soil as residue where they were fed.
+
+### How much of a perennial's roots is returned each year
+
+Perennial roots are handled differently from the above-ground crop, and you do not enter any of this — Holos works it out from the length of the stand and what follows it.
+
+-	While a stand continues, **30%** of the root mass turns over and is returned to the soil each year. The remainder stays alive in the ground.
+-	The root mass builds up over the life of the stand rather than starting fresh each year — it grows by about 19% a year for the first five years, then holds steady. A stand's first year also has a minimum: root carbon is never taken as less than 450 kg C per hectare. On a low-yielding perennial that minimum is what sets the first year, which is why several stands can start from the same figure and climb the same way.
+-	When the stand is **ploughed under and a different crop follows it**, the whole accumulated root mass is returned to the soil in that final year. You will see below-ground carbon input rise sharply in that year, which is expected.
+-	A stand that is **not** ploughed under keeps the 30% turnover right through its last year, with no rise. That covers native rangeland, which is never harvested, and any perennial that is still growing at the end of your simulation period — the simulation simply stops, it does not terminate the stand.
+-	So whether the last year of a perennial shows a jump depends on whether a crop follows it in the rotation, not on it being the last year on screen.
+
 ### Values Holos calculates for you
 
 -	On the Details screen, **white cells are values you enter** and **grey cells are calculated by Holos**. For a perennial that is grazed, or that has a hay harvest under the Custom Yield method, the yield, plant carbon in product, and percentage of product returned to soil are all calculated.


### PR DESCRIPTION
Two behaviours users see and ask about, neither of which was documented. Both are additions to Chapter 8's perennial section; no existing text changes.

## Feeding your own hay back

Hay cut from a field and fed to animals on the same farm is not counted as exported - but only when the bales record where they came from. That is **two** columns on the supplemental hay table: **Source of bales** set to **On-farm**, and then the field chosen in the **Field** column beside it. The guide previously mentioned Source of bales once, in passing, as the way to bring in off-farm hay.

Getting it wrong is consequential on a field that is also grazed, because the grazed share and the hay export come off the same crop - hay wrongly counted as exported is removed twice. That is the situation behind #465, where a user had entered it correctly and Holos was failing to use it.

The note also separates this from **Supplemental feeding loss (%)**, which is a different thing and easy to conflate.

## How perennial roots are returned

Nothing anywhere covered the 30% annual turnover, the build-up over the life of the stand, the 450 kg C first-year minimum, or what happens at termination.

The distinction worth documenting is the one #467 just corrected: the whole root mass is returned when a stand is **ploughed under and a different crop follows it**, while a stand still growing at the end of the simulation period is not terminated and keeps the 30% through its last year. So whether a perennial's last year shows a jump in below-ground carbon depends on what follows it in the rotation, not on it being the last year on screen - which is not something a user could work out from the interface.

The 450 kg minimum is included because it caused a support question of its own (#375): several low-yielding stands start from the same figure and climb identically, which looks like a bug until you know about the floor.

## Not included

A grazed-and-hayed field is modelled as a single standing crop, which is the assumption behind #466. Held deliberately until the modelling side decides whether Holos will support hay followed by aftermath grazing, since the wording differs a lot between "Holos assumes this" and "Holos cannot model that yet".

## Checks

GUI labels quoted verbatim from the resources rather than from memory - **Source of bales**, **On-farm**, **Off-farm**, **Field**, **Add Supplemental Hay/Forage for Grazing Animals**. The first draft said to set Source of bales *to the field*, which is wrong; it is two separate columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)