### PR TITLE
Say that a grazed and hayed field is modelled as one crop

### DIFF
--- a/H.Content/Documentation/User Guide/User Guide.md
+++ b/H.Content/Documentation/User Guide/User Guide.md
@@ -2399,6 +2399,10 @@ Both columns describe the same 1 hectare field, grazed at a **utilization rate o
 
 Both paths follow the screens in order: everything about the field, the animals and the cut is entered on **Component Selection**, and the **Yield Assignment Method** exists only on the **Details** screen, so choosing it is always the last step. If you do go back to Component Selection afterwards — to change a bale count, say — use **Reload Data From Previous Screen** on the Details screen so the per-year rows pick the change up.
 
+> *Note: Holos treats a grazed and hayed field as **one** standing crop. Everything the animals ate and everything you baled are taken from that same total, which assumes the animals and the hay were competing for the same growth.*
+>
+> *This means Holos cannot at present represent a field that is cut for hay and then grazed later in the season, where the animals are eating regrowth rather than the hay crop. Entered as a hay cut plus grazing on the same field, both removals come off one crop, so the field can appear to have had more taken from it than it grew. If that describes how you manage a field, contact the Holos team before relying on the carbon results for it.*
+
 ### If there is no harvest and no grazing
 
 -	Nothing removes product from the field, so 100% of it is returned to the soil. Holos sets this for you; earlier versions asked you to change it by hand.


### PR DESCRIPTION
The *If the field is both grazed and hayed* section describes both removals coming off the same total, but never states the assumption underneath it. A user whose field is cut for hay and then grazed on the regrowth has no way to tell that their management is not represented — and the symptom they do see is a warning that reads like a fault in their own data.

Adds a note immediately after that section, next to the claim it qualifies:

> Holos treats a grazed and hayed field as **one** standing crop … This means Holos cannot at present represent a field that is cut for hay and then grazed later in the season, where the animals are eating regrowth rather than the hay crop … If that describes how you manage a field, contact the Holos team before relying on the carbon results for it.

Four lines, using the guide's existing `> *Note:*` convention. No existing text changes.

## Why it does not describe the workaround

There is a usable approximation (see #466), but it is deliberately not published here:

- it depends on the field staying on **Custom Yield** — under any other method the yield is derived as forage eaten divided by the utilization rate, so the near-zero rate it relies on inflates the yield enormously
- it is undone by one click of **Reset Defaults → Grazing utilization rate**
- it asks the user to record something untrue of their field, which is a different proposition in a published document than in a supported conversation
- it would become wrong if the model gains a method for aftermath grazing, and farms built on it would then be double-corrected

Pointing at the team instead keeps those two conditions verifiable per farm. If the workaround is later worth publishing, the FAQ is a better home than the guide — easier to retire — and it should carry the modelling team's sign-off, since telling users how to represent a management system is a modelling instruction rather than a UI tip.

## Related

- #466 — the gap itself, and the interim workaround
- #465 — a separate defect on the same farm, already fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)